### PR TITLE
Creación clase MercadoPagoActivity

### DIFF
--- a/sdk/src/androidTest/java/com/mercadopago/CheckoutActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/CheckoutActivityTest.java
@@ -76,8 +76,8 @@ public class CheckoutActivityTest {
         CheckoutActivity activity = mTestRule.launchActivity(validStartIntent);
         assertTrue(activity.mCheckoutPreference != null
                 && activity.mCheckoutPreferenceId.equals(PREF_ID)
-                && activity.mMerchantPublicKey != null
-                && activity.mMerchantPublicKey.equals("1234"));
+                && activity.getMerchantPublicKey() != null
+                && activity.getMerchantPublicKey().equals("1234"));
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/mercadopago/InstructionsActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/InstructionsActivityTest.java
@@ -73,7 +73,7 @@ public class InstructionsActivityTest {
         Instruction instructionWithoutActions = StaticMock.getInstructionWithoutActions();
         mTestRule.addApiResponseToQueue(instructionWithoutActions, 200, "");
         InstructionsActivity activity = mTestRule.launchActivity(validStartIntent);
-        assertEquals(activity.mMerchantPublicKey, mMerchantPublicKey);
+        assertEquals(activity.getMerchantPublicKey(), mMerchantPublicKey);
         assertEquals(activity.mPayment.getId(), mPayment.getId());
         assertEquals(activity.mPaymentMethod.getId(), mPaymentMethod.getId());
     }

--- a/sdk/src/androidTest/java/com/mercadopago/InstructionsActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/InstructionsActivityTest.java
@@ -19,7 +19,6 @@ import com.mercadopago.util.JsonUtil;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/sdk/src/androidTest/java/com/mercadopago/PaymentVaultActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/PaymentVaultActivityTest.java
@@ -67,7 +67,7 @@ public class PaymentVaultActivityTest {
     @Test
     public void setPublicKeyOnCreate() {
         mTestRule.launchActivity(validStartIntent);
-        assertTrue(mTestRule.getActivity().mMerchantPublicKey != null);
+        assertTrue(mTestRule.getActivity().getMerchantPublicKey() != null);
     }
 
     @Test

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -39,44 +39,42 @@
         <activity
             android:name=".CheckoutActivity"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.ProcessMercadoPagoTheme.NoActionbar"/>
-
+            android:theme="@style/Theme.ProcessMercadoPagoTheme.NoActionbar" />
         <activity
             android:name=".GuessingCardActivity"
             android:screenOrientation="portrait"
-            android:windowSoftInputMode="adjustResize"
-            android:theme="@style/Theme.ProcessMercadoPagoTheme.NoActionbar"/>
-
+            android:theme="@style/Theme.ProcessMercadoPagoTheme.NoActionbar"
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".PaymentVaultActivity"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.ProcessMercadoPagoTheme.NoActionbar"/>
-
+            android:theme="@style/Theme.ProcessMercadoPagoTheme.NoActionbar" />
         <activity
             android:name=".InstructionsActivity"
             android:launchMode="singleTask"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.InfoMercadoPagoTheme.NoActionbar"/>
-
+            android:theme="@style/Theme.InfoMercadoPagoTheme.NoActionbar" />
         <activity
             android:name=".CongratsActivity"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.MercadoPagoTheme.NoActionBar"/>
-
-        <activity android:name=".InstallmentsActivity"
+            android:theme="@style/Theme.MercadoPagoTheme.NoActionBar" />
+        <activity
+            android:name=".InstallmentsActivity"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.ProcessMercadoPagoTheme.NoActionbar"/>
-
-        <activity android:name=".IssuersActivity"
+            android:theme="@style/Theme.ProcessMercadoPagoTheme.NoActionbar" />
+        <activity
+            android:name=".IssuersActivity"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.ProcessMercadoPagoTheme.NoActionbar"/>
-
-        <activity android:name=".CardVaultActivity"
+            android:theme="@style/Theme.ProcessMercadoPagoTheme.NoActionbar" />
+        <activity
+            android:name=".CardVaultActivity"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.ProcessMercadoPagoTheme.NoActionbar"/>
-
-        <activity android:name=".ErrorActivity"
+            android:theme="@style/Theme.ProcessMercadoPagoTheme.NoActionbar" />
+        <activity
+            android:name=".ErrorActivity"
             android:screenOrientation="portrait"
             android:theme="@style/Theme.MercadoPagoTheme.NoActionBar" />
+        <activity android:name=".MercadoPagoActivity"></activity>
     </application>
+
 </manifest>

--- a/sdk/src/main/java/com/mercadopago/BankDealsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/BankDealsActivity.java
@@ -42,7 +42,7 @@ public class BankDealsActivity extends MercadoPagoActivity {
     }
 
     @Override
-    protected void showError(String message) {
+    protected void onInvalidStart(String message) {
         ErrorUtil.startErrorActivity(this, message, false);
     }
 

--- a/sdk/src/main/java/com/mercadopago/BankDealsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/BankDealsActivity.java
@@ -62,16 +62,22 @@ public class BankDealsActivity extends MercadoPagoActivity {
 
     private void initializeToolbar() {
         mToolbar = (Toolbar) findViewById(R.id.mpsdkToolbar);
+        TextView title = (TextView) findViewById(R.id.mpsdkTitle);
+
         setSupportActionBar(mToolbar);
         getSupportActionBar().setDisplayShowTitleEnabled(false);
+        getSupportActionBar().setDisplayShowTitleEnabled(false);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setDisplayShowHomeEnabled(true);
+        mToolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                onBackPressed();
+            }
+        });
 
-        if(isCustomColorSet()) {
-            mToolbar.setBackgroundColor(getCustomBaseColor());
-        }
-        if(mDecorationPreference.isDarkFontEnabled()) {
-            TextView title = (TextView) findViewById(R.id.mpsdkTitle);
-            title.setTextColor(getDarkFontColor());
-        }
+        decorate(mToolbar);
+        decorate(title);
     }
 
     @Override
@@ -116,5 +122,12 @@ public class BankDealsActivity extends MercadoPagoActivity {
                 }
             }
         });
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if(requestCode == ErrorUtil.ERROR_REQUEST_CODE) {
+            finish();
+        }
     }
 }

--- a/sdk/src/main/java/com/mercadopago/CheckoutActivity.java
+++ b/sdk/src/main/java/com/mercadopago/CheckoutActivity.java
@@ -140,11 +140,6 @@ public class CheckoutActivity extends MercadoPagoActivity {
     }
 
     @Override
-    protected void showError(String message) {
-        ErrorUtil.startErrorActivity(this, message, false);
-    }
-
-    @Override
     protected void onValidStart() {
         MPTracker.getInstance().trackEvent("CHECKOUT", "INIT_CHECKOUT", "3", getMerchantPublicKey(), "MLA", "1.0", this);
         mBackPressedOnce = false;
@@ -155,6 +150,11 @@ public class CheckoutActivity extends MercadoPagoActivity {
                 .build();
 
         getCheckoutPreference();
+    }
+
+    @Override
+    protected void onInvalidStart(String message) {
+        ErrorUtil.startErrorActivity(this, message, false);
     }
 
     private void getCheckoutPreference() {

--- a/sdk/src/main/java/com/mercadopago/CheckoutActivity.java
+++ b/sdk/src/main/java/com/mercadopago/CheckoutActivity.java
@@ -124,13 +124,7 @@ public class CheckoutActivity extends MercadoPagoActivity {
                 createPayment();
             }
         });
-
-        if(isCustomColorSet()) {
-            mPayButton.setBackgroundColor(getCustomBaseColor());
-        }
-        if(isDarkFontEnabled()) {
-            mPayButton.setTextColor(getDarkFontColor());
-        }
+        decorate(mPayButton);
 
         mTotalAmountTextView = (MPTextView) findViewById(R.id.mpsdkTotalAmountText);
         mPaymentMethodLayout = (RelativeLayout) findViewById(R.id.mpsdkPaymentMethodLayout);

--- a/sdk/src/main/java/com/mercadopago/CustomerCardsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/CustomerCardsActivity.java
@@ -36,7 +36,7 @@ public class CustomerCardsActivity extends MercadoPagoActivity {
     }
 
     @Override
-    protected void showError(String message) {
+    protected void onInvalidStart(String message) {
         ErrorUtil.startErrorActivity(this, message, false);
     }
 

--- a/sdk/src/main/java/com/mercadopago/CustomerCardsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/CustomerCardsActivity.java
@@ -3,8 +3,6 @@ package com.mercadopago;
 import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
-import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
@@ -17,14 +15,14 @@ import com.mercadopago.adapters.CustomerCardsAdapter;
 import com.mercadopago.callbacks.OnSelectedCallback;
 import com.mercadopago.decorations.DividerItemDecoration;
 import com.mercadopago.model.Card;
-import com.mercadopago.model.DecorationPreference;
 import com.mercadopago.mptracker.MPTracker;
+import com.mercadopago.util.ErrorUtil;
 import com.mercadopago.util.JsonUtil;
 
 import java.lang.reflect.Type;
 import java.util.List;
 
-public class CustomerCardsActivity extends AppCompatActivity {
+public class CustomerCardsActivity extends MercadoPagoActivity {
 
     private RecyclerView mRecyclerView;
     private Toolbar mToolbar;
@@ -32,31 +30,14 @@ public class CustomerCardsActivity extends AppCompatActivity {
 
     private List<Card> mCards;
 
-    private DecorationPreference mDecorationPreference;
+    @Override
+    protected void onValidStart() {
+        fillData();
+    }
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        getActivityParameters();
-
-        if(mDecorationPreference != null && mDecorationPreference.hasColors()) {
-            setTheme(R.style.Theme_MercadoPagoTheme_NoActionBar);
-        }
-
-        setContentView();
-
-        initializeToolbar();
-
-        if (mCards == null) {
-            Intent returnIntent = new Intent();
-            setResult(RESULT_CANCELED, returnIntent);
-            finish();
-            return;
-        }
-
-        initializeControls();
-        fillData();
+    protected void showError(String message) {
+        ErrorUtil.startErrorActivity(this, message, false);
     }
 
     protected void setContentView() {
@@ -80,21 +61,20 @@ public class CustomerCardsActivity extends AppCompatActivity {
             }
         });
 
-        if(mDecorationPreference != null) {
-            if(mDecorationPreference.hasColors()) {
-                mToolbar.setBackgroundColor(mDecorationPreference.getBaseColor());
-            }
-            if(mDecorationPreference.isDarkFontEnabled()) {
-                mTitle.setTextColor(mDecorationPreference.getDarkFontColor(this));
-                Drawable upArrow = mToolbar.getNavigationIcon();
-                upArrow.setColorFilter(mDecorationPreference.getDarkFontColor(this), PorterDuff.Mode.SRC_ATOP);
-                getSupportActionBar().setHomeAsUpIndicator(upArrow);
-            }
+        if(isCustomColorSet()) {
+            mToolbar.setBackgroundColor(getCustomBaseColor());
+        }
+        if(isDarkFontEnabled()) {
+            mTitle.setTextColor(getDarkFontColor());
+            Drawable upArrow = mToolbar.getNavigationIcon();
+            upArrow.setColorFilter(getDarkFontColor(), PorterDuff.Mode.SRC_ATOP);
+            getSupportActionBar().setHomeAsUpIndicator(upArrow);
         }
     }
 
-    private void getActivityParameters() {
-
+    @Override
+    protected void getActivityParameters() {
+        super.getActivityParameters();
         try {
             Gson gson = new Gson();
             Type listType = new TypeToken<List<Card>>(){}.getType();
@@ -102,13 +82,18 @@ public class CustomerCardsActivity extends AppCompatActivity {
         } catch (Exception ex) {
             mCards = null;
         }
+    }
 
-        if(getIntent().getStringExtra("decorationPreference") != null) {
-            mDecorationPreference = JsonUtil.getInstance().fromJson(getIntent().getStringExtra("decorationPreference"), DecorationPreference.class);
+    @Override
+    protected void validateActivityParameters() throws IllegalStateException {
+        if(mCards == null) {
+            throw new IllegalStateException("cards not set");
         }
     }
 
-    private void initializeControls() {
+    @Override
+    protected void initializeControls() {
+        initializeToolbar();
         mRecyclerView = (RecyclerView) findViewById(R.id.mpsdkCustomerCardsList);
     }
 

--- a/sdk/src/main/java/com/mercadopago/ErrorActivity.java
+++ b/sdk/src/main/java/com/mercadopago/ErrorActivity.java
@@ -69,8 +69,7 @@ public class ErrorActivity extends AppCompatActivity {
 
         this.mErrorMessageTextView.setText(message);
 
-        if (mMPException.isRecoverable())
-        {
+        if (mMPException.isRecoverable()) {
             mRetryTextView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {

--- a/sdk/src/main/java/com/mercadopago/FrontCardActivity.java
+++ b/sdk/src/main/java/com/mercadopago/FrontCardActivity.java
@@ -17,7 +17,6 @@ public abstract class FrontCardActivity extends AppCompatActivity implements Car
     protected String mSecurityCode = "";
     protected PaymentMethod mCurrentPaymentMethod;
 
-
     public String getCardNumber() {
         return mCardNumber;
     }

--- a/sdk/src/main/java/com/mercadopago/InstructionsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/InstructionsActivity.java
@@ -52,7 +52,7 @@ public class InstructionsActivity extends MercadoPagoActivity {
     protected PaymentMethod mPaymentMethod;
 
     @Override
-    protected void showError(String message) {
+    protected void onInvalidStart(String message) {
         ErrorUtil.startErrorActivity(this, message, false);
     }
 

--- a/sdk/src/main/java/com/mercadopago/InstructionsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/InstructionsActivity.java
@@ -1,11 +1,8 @@
 package com.mercadopago;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
-import android.os.Bundle;
 import android.support.design.widget.Snackbar;
-import android.support.v7.app.AppCompatActivity;
 import android.text.Html;
 import android.text.Spanned;
 import android.util.TypedValue;
@@ -34,17 +31,14 @@ import com.mercadopago.views.MPTextView;
 
 import java.util.List;
 
-public class InstructionsActivity extends AppCompatActivity {
+public class InstructionsActivity extends MercadoPagoActivity {
 
     //Values
     protected MercadoPago mMercadoPago;
-    protected FailureRecovery failureRecovery;
     protected Boolean mBackPressedOnce;
-    protected boolean mActiveActivity;
 
     //Controls
     protected LinearLayout mReferencesLayout;
-    protected Activity mActivity;
     protected MPTextView mTitle;
     protected MPTextView mPrimaryInfo;
     protected MPTextView mSecondaryInfo;
@@ -55,23 +49,26 @@ public class InstructionsActivity extends AppCompatActivity {
 
     //Params
     protected Payment mPayment;
-    protected String mMerchantPublicKey;
     protected PaymentMethod mPaymentMethod;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.mpsdk_activity_instructions);
-        getActivityParameters();
-        initializeControls();
+    protected void showError(String message) {
+        ErrorUtil.startErrorActivity(this, message, false);
+    }
+
+    @Override
+    protected void onValidStart() {
         mBackPressedOnce = false;
-        mActivity = this;
-        mActiveActivity = true;
         mMercadoPago = new MercadoPago.Builder()
                 .setContext(this)
-                .setPublicKey(mMerchantPublicKey)
+                .setPublicKey(getMerchantPublicKey())
                 .build();
         getInstructionsAsync();
+    }
+
+    @Override
+    protected void setContentView() {
+        setContentView(R.layout.mpsdk_activity_instructions);
     }
 
     protected void getInstructionsAsync() {
@@ -80,29 +77,29 @@ public class InstructionsActivity extends AppCompatActivity {
         mMercadoPago.getInstructions(mPayment.getId(), mPaymentMethod.getPaymentTypeId(), new Callback<Instruction>() {
             @Override
             public void success(Instruction instruction) {
-                MPTracker.getInstance().trackEvent( "INSTRUCTIONS", "GET_INSTRUCTION_RESPONSE", "SUCCESS", "2", mMerchantPublicKey, "MLA", "1.0", mActivity);
+                MPTracker.getInstance().trackEvent("INSTRUCTIONS", "GET_INSTRUCTION_RESPONSE", "SUCCESS", "2", getMerchantPublicKey(), "MLA", "1.0", getActivity());
                 showInstructions(instruction);
-                LayoutUtil.showRegularLayout(mActivity);
+                LayoutUtil.showRegularLayout(getActivity());
             }
 
             @Override
             public void failure(ApiException apiException) {
-                MPTracker.getInstance().trackEvent( "INSTRUCTIONS", "GET_INSTRUCTION_RESPONSE", "FAIL", "2", mMerchantPublicKey, "MLA", "1.0", mActivity);
-                if (mActiveActivity) {
-                    ApiUtil.showApiExceptionError(mActivity, apiException);
-                    failureRecovery = new FailureRecovery() {
+                MPTracker.getInstance().trackEvent("INSTRUCTIONS", "GET_INSTRUCTION_RESPONSE", "FAIL", "2", getMerchantPublicKey(), "MLA", "1.0", getActivity());
+                if (isActivityActive()) {
+                    ApiUtil.showApiExceptionError(getActivity(), apiException);
+                    setFailureRecovery(new FailureRecovery() {
                         @Override
                         public void recover() {
                             getInstructionsAsync();
                         }
-                    };
+                    });
                 }
             }
         });
     }
 
     protected void showInstructions(Instruction instruction) {
-        MPTracker.getInstance().trackScreen( "INSTRUCTIONS", "2", mMerchantPublicKey, "MLA", "1.0", this);
+        MPTracker.getInstance().trackScreen( "INSTRUCTIONS", "2", getMerchantPublicKey(), "MLA", "1.0", this);
 
         setTitle(instruction.getTitle());
         setInformationMessages(instruction);
@@ -199,12 +196,27 @@ public class InstructionsActivity extends AppCompatActivity {
         return stringBuilder.toString();
     }
 
+    @Override
     protected void getActivityParameters() {
+        super.getActivityParameters();
         mPayment = JsonUtil.getInstance().fromJson(getIntent().getStringExtra("payment"), Payment.class);
-        mMerchantPublicKey = this.getIntent().getStringExtra("merchantPublicKey");
         mPaymentMethod = JsonUtil.getInstance().fromJson(getIntent().getStringExtra("paymentMethod"), PaymentMethod.class);
     }
 
+    @Override
+    protected void validateActivityParameters() throws IllegalStateException {
+        if(getMerchantPublicKey() == null) {
+            throw new IllegalStateException("merchant public key not set");
+        }
+        if(mPayment == null) {
+            throw new IllegalStateException("payment not set");
+        }
+        if(mPaymentMethod == null) {
+            throw new IllegalStateException("payment method not set");
+        }
+    }
+
+    @Override
     protected void initializeControls() {
         mReferencesLayout = (LinearLayout) findViewById(R.id.mpsdkReferencesLayout);
         mTitle = (MPTextView) findViewById(R.id.mpsdkTitle);
@@ -240,43 +252,13 @@ public class InstructionsActivity extends AppCompatActivity {
         overridePendingTransition(R.anim.mpsdk_slide_right_to_left_in, R.anim.mpsdk_slide_right_to_left_out);
     }
 
-    private void recoverFromFailure() {
-        if(failureRecovery != null) {
-            failureRecovery.recover();
-        }
-    }
-
-    @Override
-    protected void onResume() {
-        mActiveActivity = true;
-        super.onResume();
-    }
-
-    @Override
-    protected void onDestroy() {
-        mActiveActivity = false;
-        super.onDestroy();
-    }
-
-    @Override
-    protected void onPause() {
-        mActiveActivity = false;
-        super.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        mActiveActivity = false;
-        super.onStop();
-    }
-
     @Override
     public void onBackPressed() {
         if(mBackPressedOnce) {
             super.onBackPressed();
         }
         else {
-            MPTracker.getInstance().trackEvent("INSTRUCTION", "BACK_PRESSED", "2", mMerchantPublicKey, "MLA", "1.0", this);
+            MPTracker.getInstance().trackEvent("INSTRUCTION", "BACK_PRESSED", "2", getMerchantPublicKey(), "MLA", "1.0", this);
             Snackbar.make(mTertiaryInfo, getString(R.string.mpsdk_press_again_to_leave), Snackbar.LENGTH_LONG).show();
             mBackPressedOnce = true;
             resetBackPressedOnceIn(4000);

--- a/sdk/src/main/java/com/mercadopago/MercadoPagoActivity.java
+++ b/sdk/src/main/java/com/mercadopago/MercadoPagoActivity.java
@@ -1,9 +1,14 @@
 package com.mercadopago;
 
 import android.app.Activity;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.widget.Button;
+import android.widget.TextView;
 
 import com.mercadopago.callbacks.FailureRecovery;
 import com.mercadopago.model.DecorationPreference;
@@ -133,5 +138,40 @@ public abstract class MercadoPagoActivity extends AppCompatActivity {
         return mDecorationPreference.getDarkFontColor(this);
     }
 
+    protected void decorate(Button button) {
+        if(isCustomColorSet()) {
+            button.setBackgroundColor(getCustomBaseColor());
+        }
 
+        if(isDarkFontEnabled()) {
+            button.setTextColor(getDarkFontColor());
+        }
+    }
+
+    protected void decorate(Toolbar toolbar) {
+        if(toolbar != null) {
+            if (isCustomColorSet()) {
+                toolbar.setBackgroundColor(getCustomBaseColor());
+            }
+
+            if (isDarkFontEnabled()) {
+                int darkFont = getDarkFontColor();
+                Drawable upArrow = toolbar.getNavigationIcon();
+                if (upArrow != null) {
+                    upArrow.setColorFilter(darkFont, PorterDuff.Mode.SRC_ATOP);
+                    if (getSupportActionBar() != null) {
+                        getSupportActionBar().setHomeAsUpIndicator(upArrow);
+                    }
+                }
+            }
+        }
+    }
+
+    protected void decorate(TextView textView) {
+        if(textView != null) {
+            if (isDarkFontEnabled()) {
+                textView.setTextColor(getDarkFontColor());
+            }
+        }
+    }
 }

--- a/sdk/src/main/java/com/mercadopago/MercadoPagoActivity.java
+++ b/sdk/src/main/java/com/mercadopago/MercadoPagoActivity.java
@@ -31,13 +31,13 @@ public abstract class MercadoPagoActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getActivityParameters();
         if(mDecorationPreference != null && mDecorationPreference.hasColors()) {
             setTheme(R.style.Theme_MercadoPagoTheme_NoActionBar);
         }
         setActivity();
         mActivityActive = true;
         setContentView();
-        getActivityParameters();
         try {
             validateActivityParameters();
             initializeControls();

--- a/sdk/src/main/java/com/mercadopago/MercadoPagoActivity.java
+++ b/sdk/src/main/java/com/mercadopago/MercadoPagoActivity.java
@@ -1,0 +1,137 @@
+package com.mercadopago;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.support.annotation.CallSuper;
+import android.support.v7.app.AppCompatActivity;
+
+import com.mercadopago.callbacks.FailureRecovery;
+import com.mercadopago.model.DecorationPreference;
+import com.mercadopago.model.PaymentPreference;
+import com.mercadopago.util.JsonUtil;
+
+public abstract class MercadoPagoActivity extends AppCompatActivity {
+
+    private boolean mActivityActive;
+    private String mMerchantPublicKey;
+    protected String mMerchantBaseUrl;
+    protected String mMerchantGetCustomerUri;
+    protected String mMerchantCreatePaymentUri;
+    protected String mMerchantAccessToken;
+    protected DecorationPreference mDecorationPreference;
+    protected PaymentPreference mPaymentPreference;
+    private FailureRecovery mFailureRecovery;
+    private Activity mActivity;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if(mDecorationPreference != null && mDecorationPreference.hasColors()) {
+            setTheme(R.style.Theme_MercadoPagoTheme_NoActionBar);
+        }
+        setActivity();
+        mActivityActive = true;
+        setContentView();
+        getActivityParameters();
+        try {
+            validateActivityParameters();
+            initializeControls();
+            onValidStart();
+        } catch (IllegalStateException exception) {
+            showError(exception.getMessage());
+        }
+    }
+
+    private void setActivity() {
+        mActivity = this;
+    }
+
+    protected Activity getActivity() {
+       return mActivity;
+    }
+
+    protected String getMerchantPublicKey() {
+        return mMerchantPublicKey;
+    }
+
+    protected abstract void onValidStart();
+
+    protected abstract void showError(String message);
+
+    protected abstract void setContentView();
+
+    protected abstract void initializeControls();
+
+    @CallSuper
+    protected void getActivityParameters() {
+        if(getIntent().getStringExtra("paymentPreference") != null) {
+            mPaymentPreference = JsonUtil.getInstance().fromJson(getIntent().getStringExtra("paymentPreference"), PaymentPreference.class);
+        }
+        if(getIntent().getStringExtra("decorationPreference") != null) {
+            mDecorationPreference = JsonUtil.getInstance().fromJson(getIntent().getStringExtra("decorationPreference"), DecorationPreference.class);
+        }
+        mMerchantPublicKey = getIntent().getStringExtra("merchantPublicKey");
+        mMerchantBaseUrl = getIntent().getStringExtra("merchantBaseUrl");
+        mMerchantGetCustomerUri = getIntent().getStringExtra("getCustomerUri");
+        mMerchantCreatePaymentUri = getIntent().getStringExtra("createPaymentUri");
+        mMerchantAccessToken = getIntent().getStringExtra("merchantAccessToken");
+    };
+
+    protected abstract void validateActivityParameters() throws IllegalStateException;
+
+    @Override
+    protected void onResume() {
+        mActivityActive = true;
+        super.onResume();
+    }
+
+    @Override
+    protected void onDestroy() {
+        mActivityActive = false;
+        super.onDestroy();
+    }
+
+    @Override
+    protected void onPause() {
+        mActivityActive = false;
+        super.onPause();
+    }
+
+    @Override
+    protected void onStop() {
+        mActivityActive = false;
+        super.onStop();
+    }
+
+    protected boolean isActivityActive() {
+        return mActivityActive;
+    }
+
+    protected void setFailureRecovery(FailureRecovery failureRecovery) {
+        this.mFailureRecovery = failureRecovery;
+    }
+
+    protected void recoverFromFailure() {
+        if (mFailureRecovery != null) {
+            mFailureRecovery.recover();
+        }
+    }
+
+    protected boolean isCustomColorSet() {
+        return mDecorationPreference != null && mDecorationPreference.hasColors();
+    }
+
+    protected int getCustomBaseColor() {
+        return mDecorationPreference.getBaseColor();
+    }
+
+    protected boolean isDarkFontEnabled() {
+        return mDecorationPreference != null && mDecorationPreference.isDarkFontEnabled();
+    }
+
+    protected int getDarkFontColor() {
+        return mDecorationPreference.getDarkFontColor(this);
+    }
+
+
+}

--- a/sdk/src/main/java/com/mercadopago/MercadoPagoActivity.java
+++ b/sdk/src/main/java/com/mercadopago/MercadoPagoActivity.java
@@ -38,7 +38,7 @@ public abstract class MercadoPagoActivity extends AppCompatActivity {
             initializeControls();
             onValidStart();
         } catch (IllegalStateException exception) {
-            showError(exception.getMessage());
+            onInvalidStart(exception.getMessage());
         }
     }
 
@@ -56,7 +56,7 @@ public abstract class MercadoPagoActivity extends AppCompatActivity {
 
     protected abstract void onValidStart();
 
-    protected abstract void showError(String message);
+    protected abstract void onInvalidStart(String message);
 
     protected abstract void setContentView();
 

--- a/sdk/src/main/java/com/mercadopago/PaymentMethodsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/PaymentMethodsActivity.java
@@ -77,17 +77,10 @@ public class PaymentMethodsActivity extends MercadoPagoActivity {
             });
         }
 
-        if(isCustomColorSet()) {
-            mToolbar.setBackgroundColor(getCustomBaseColor());
-        }
-        if(isDarkFontEnabled()) {
-            mTitle.setTextColor(getDarkFontColor());
-            Drawable upArrow = mToolbar.getNavigationIcon();
-            upArrow.setColorFilter(getDarkFontColor(), PorterDuff.Mode.SRC_ATOP);
-            getSupportActionBar().setHomeAsUpIndicator(upArrow);
-            if(mShowBankDeals) {
-                mBankDealsTextView.setTextColor(getDarkFontColor());
-            }
+        decorate(mToolbar);
+        decorate(mTitle);
+        if(mShowBankDeals) {
+            decorate(mBankDealsTextView);
         }
     }
 

--- a/sdk/src/main/java/com/mercadopago/PaymentMethodsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/PaymentMethodsActivity.java
@@ -1,8 +1,6 @@
 package com.mercadopago;
 
 import android.content.Intent;
-import android.graphics.PorterDuff;
-import android.graphics.drawable.Drawable;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;

--- a/sdk/src/main/java/com/mercadopago/PaymentMethodsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/PaymentMethodsActivity.java
@@ -1,11 +1,8 @@
 package com.mercadopago;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
-import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
@@ -18,9 +15,7 @@ import com.mercadopago.callbacks.FailureRecovery;
 import com.mercadopago.core.MercadoPago;
 import com.mercadopago.decorations.DividerItemDecoration;
 import com.mercadopago.model.ApiException;
-import com.mercadopago.model.DecorationPreference;
 import com.mercadopago.model.PaymentMethod;
-import com.mercadopago.model.PaymentPreference;
 import com.mercadopago.mptracker.MPTracker;
 import com.mercadopago.util.ApiUtil;
 import com.mercadopago.util.ErrorUtil;
@@ -30,18 +25,10 @@ import com.mercadopago.util.LayoutUtil;
 import java.util.ArrayList;
 import java.util.List;
 
-public class PaymentMethodsActivity extends AppCompatActivity {
+public class PaymentMethodsActivity extends MercadoPagoActivity {
 
     protected MercadoPago mMercadoPago;
-    private String mMerchantPublicKey;
     private boolean mShowBankDeals;
-    private FailureRecovery mFailureRecovery;
-    protected boolean mActiveActivity;
-
-    private PaymentPreference mPaymentPreference;
-    private DecorationPreference mDecorationPreference;
-
-    private Activity mActivity;
 
     private RecyclerView mRecyclerView;
     private Toolbar mToolbar;
@@ -49,54 +36,14 @@ public class PaymentMethodsActivity extends AppCompatActivity {
     private TextView mTitle;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        getActivityParameters();
-        if(mDecorationPreference != null && mDecorationPreference.hasColors()) {
-            setTheme(R.style.Theme_MercadoPagoTheme_NoActionBar);
-        }
-        setContentView();
-        mActivity = this;
-        mActiveActivity = true;
-
-        initializeToolbar();
-        mMercadoPago = createMercadoPago(mMerchantPublicKey);
-
-        // Set recycler view
-        mRecyclerView = (RecyclerView) findViewById(R.id.mpsdkPaymentMethodsList);
-        mRecyclerView.setHasFixedSize(true);
-        mRecyclerView.addItemDecoration(new DividerItemDecoration(this, DividerItemDecoration.VERTICAL_LIST));
-
-        // Set a linear layout manager
-        mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
-
-        // Load payment methods
+    protected void onValidStart() {
+        mMercadoPago = createMercadoPago(getMerchantPublicKey());
         getPaymentMethodsAsync();
-
     }
 
     @Override
-    protected void onResume() {
-        mActiveActivity = true;
-        super.onResume();
-    }
-
-    @Override
-    protected void onDestroy() {
-        mActiveActivity = false;
-        super.onDestroy();
-    }
-
-    @Override
-    protected void onPause() {
-        mActiveActivity = false;
-        super.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        mActiveActivity = false;
-        super.onStop();
+    protected void showError(String message) {
+        ErrorUtil.startErrorActivity(this, message, false);
     }
 
     private void initializeToolbar() {
@@ -122,26 +69,24 @@ public class PaymentMethodsActivity extends AppCompatActivity {
                 @Override
                 public void onClick(View v) {
                     new MercadoPago.StartActivityBuilder()
-                            .setActivity(mActivity)
-                            .setPublicKey(mMerchantPublicKey)
+                            .setActivity(getActivity())
+                            .setPublicKey(getMerchantPublicKey())
                             .setDecorationPreference(mDecorationPreference)
                             .startBankDealsActivity();
                 }
             });
         }
 
-        if(mDecorationPreference != null) {
-            if(mDecorationPreference.hasColors()) {
-                mToolbar.setBackgroundColor(mDecorationPreference.getBaseColor());
-            }
-            if(mDecorationPreference.isDarkFontEnabled()) {
-                mTitle.setTextColor(mDecorationPreference.getDarkFontColor(this));
-                Drawable upArrow = mToolbar.getNavigationIcon();
-                upArrow.setColorFilter(mDecorationPreference.getDarkFontColor(this), PorterDuff.Mode.SRC_ATOP);
-                getSupportActionBar().setHomeAsUpIndicator(upArrow);
-                if(mShowBankDeals) {
-                    mBankDealsTextView.setTextColor(mDecorationPreference.getDarkFontColor(this));
-                }
+        if(isCustomColorSet()) {
+            mToolbar.setBackgroundColor(getCustomBaseColor());
+        }
+        if(isDarkFontEnabled()) {
+            mTitle.setTextColor(getDarkFontColor());
+            Drawable upArrow = mToolbar.getNavigationIcon();
+            upArrow.setColorFilter(getDarkFontColor(), PorterDuff.Mode.SRC_ATOP);
+            getSupportActionBar().setHomeAsUpIndicator(upArrow);
+            if(mShowBankDeals) {
+                mBankDealsTextView.setTextColor(getDarkFontColor());
             }
         }
     }
@@ -153,32 +98,38 @@ public class PaymentMethodsActivity extends AppCompatActivity {
                 .build();
     }
 
-    private void getActivityParameters() {
-
-        mMerchantPublicKey = this.getIntent().getStringExtra("merchantPublicKey");
-        if (mMerchantPublicKey == null) {
-            Intent returnIntent = new Intent();
-            setResult(RESULT_CANCELED, returnIntent);
-            finish();
-            return;
-        }
-        if (this.getIntent().getStringExtra("paymentPreference") != null) {
-            mPaymentPreference = JsonUtil.getInstance().fromJson(this.getIntent().getStringExtra("paymentPreference"), PaymentPreference.class);
-        }
-        if (this.getIntent().getStringExtra("decorationPreference") != null) {
-            mDecorationPreference = JsonUtil.getInstance().fromJson(this.getIntent().getStringExtra("decorationPreference"), DecorationPreference.class);
-        }
+    @Override
+    protected void getActivityParameters() {
+        super.getActivityParameters();
         mShowBankDeals = this.getIntent().getBooleanExtra("showBankDeals", true);
     }
 
+    @Override
+    protected void validateActivityParameters() throws IllegalStateException {
+        if(getMerchantPublicKey() == null) {
+            throw new IllegalStateException("public key not set");
+        }
+    }
 
+    @Override
     protected void setContentView() {
-        MPTracker.getInstance().trackScreen("PAYMENT_METHODS", "2", mMerchantPublicKey, "MLA", "1.0", this);
+        MPTracker.getInstance().trackScreen("PAYMENT_METHODS", "2", getMerchantPublicKey(), "MLA", "1.0", this);
         setContentView(R.layout.mpsdk_activity_payment_methods);
     }
 
+    @Override
+    protected void initializeControls() {
+        mRecyclerView = (RecyclerView) findViewById(R.id.mpsdkPaymentMethodsList);
+        mRecyclerView.setHasFixedSize(true);
+        mRecyclerView.addItemDecoration(new DividerItemDecoration(this, DividerItemDecoration.VERTICAL_LIST));
+
+        // Set a linear layout manager
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+        initializeToolbar();
+    }
+
     public void onBackPressed() {
-        MPTracker.getInstance().trackEvent("PAYMENT_METHODS", "BACK_PRESSED", "2", mMerchantPublicKey, "MLA", "1.0", this);
+        MPTracker.getInstance().trackEvent("PAYMENT_METHODS", "BACK_PRESSED", "2", getMerchantPublicKey(), "MLA", "1.0", this);
 
         Intent returnIntent = new Intent();
         returnIntent.putExtra("backButtonPressed", true);
@@ -191,14 +142,14 @@ public class PaymentMethodsActivity extends AppCompatActivity {
     }
 
     private void getPaymentMethodsAsync() {
-        LayoutUtil.showProgressLayout(mActivity);
+        LayoutUtil.showProgressLayout(getActivity());
 
         mMercadoPago.getPaymentMethods(new Callback<List<PaymentMethod>>() {
             @Override
             public void success(List<PaymentMethod> paymentMethods) {
-                if (mActiveActivity) {
-                    MPTracker.getInstance().trackEvent("PAYMENT_METHODS", "GET_PAYMENT_METHODS_RESPONSE", "SUCCESS", "2", mMerchantPublicKey, "MLA", "1.0", mActivity);
-                    mRecyclerView.setAdapter(new PaymentMethodsAdapter(mActivity, getSupportedPaymentMethods(paymentMethods), new View.OnClickListener() {
+                if (isActivityActive()) {
+                    MPTracker.getInstance().trackEvent("PAYMENT_METHODS", "GET_PAYMENT_METHODS_RESPONSE", "SUCCESS", "2", getMerchantPublicKey(), "MLA", "1.0", getActivity());
+                    mRecyclerView.setAdapter(new PaymentMethodsAdapter(getActivity(), getSupportedPaymentMethods(paymentMethods), new View.OnClickListener() {
                         @Override
                         public void onClick(View view) {
                             // Return to parent
@@ -209,21 +160,21 @@ public class PaymentMethodsActivity extends AppCompatActivity {
                             finish();
                         }
                     }));
-                    LayoutUtil.showRegularLayout(mActivity);
+                    LayoutUtil.showRegularLayout(getActivity());
                 }
             }
 
             @Override
             public void failure(ApiException apiException) {
-                MPTracker.getInstance().trackEvent("PAYMENT_METHODS", "GET_PAYMENT_METHODS_RESPONSE", "FAIL", "2", mMerchantPublicKey, "MLA", "1.0", mActivity);
-                if (mActiveActivity) {
-                    mFailureRecovery = new FailureRecovery() {
+                MPTracker.getInstance().trackEvent("PAYMENT_METHODS", "GET_PAYMENT_METHODS_RESPONSE", "FAIL", "2", getMerchantPublicKey(), "MLA", "1.0", getActivity());
+                if (isActivityActive()) {
+                    setFailureRecovery(new FailureRecovery() {
                         @Override
                         public void recover() {
                             getPaymentMethodsAsync();
                         }
-                    };
-                    ApiUtil.showApiExceptionError(mActivity, apiException);
+                    });
+                    ApiUtil.showApiExceptionError(getActivity(), apiException);
                 }
             }
         });
@@ -270,12 +221,6 @@ public class PaymentMethodsActivity extends AppCompatActivity {
                 setResult(resultCode, data);
                 finish();
             }
-        }
-    }
-
-    private void recoverFromFailure() {
-        if(mFailureRecovery != null) {
-            mFailureRecovery.recover();
         }
     }
 }

--- a/sdk/src/main/java/com/mercadopago/PaymentMethodsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/PaymentMethodsActivity.java
@@ -42,7 +42,7 @@ public class PaymentMethodsActivity extends MercadoPagoActivity {
     }
 
     @Override
-    protected void showError(String message) {
+    protected void onInvalidStart(String message) {
         ErrorUtil.startErrorActivity(this, message, false);
     }
 

--- a/sdk/src/main/java/com/mercadopago/PaymentVaultActivity.java
+++ b/sdk/src/main/java/com/mercadopago/PaymentVaultActivity.java
@@ -122,7 +122,7 @@ public class PaymentVaultActivity extends MercadoPagoActivity {
     }
 
     @Override
-    protected void showError(String message) {
+    protected void onInvalidStart(String message) {
         ErrorUtil.startErrorActivity(this, message, false);
     }
 

--- a/sdk/src/main/java/com/mercadopago/PaymentVaultActivity.java
+++ b/sdk/src/main/java/com/mercadopago/PaymentVaultActivity.java
@@ -4,9 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
-import android.os.Bundle;
 import android.support.design.widget.AppBarLayout;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
@@ -19,7 +17,6 @@ import com.mercadopago.callbacks.FailureRecovery;
 import com.mercadopago.callbacks.OnSelectedCallback;
 import com.mercadopago.core.MercadoPago;
 import com.mercadopago.model.ApiException;
-import com.mercadopago.model.DecorationPreference;
 import com.mercadopago.model.Issuer;
 import com.mercadopago.model.PayerCost;
 import com.mercadopago.model.PaymentMethod;
@@ -40,16 +37,14 @@ import com.mercadopago.views.MPTextView;
 import java.math.BigDecimal;
 import java.util.List;
 
-public class PaymentVaultActivity extends AppCompatActivity {
+public class PaymentVaultActivity extends MercadoPagoActivity {
 
     // Local vars
-    protected Activity mActivity;
     protected MercadoPago mMercadoPago;
     protected PaymentMethod mSelectedPaymentMethod;
     protected Token mToken;
     protected Issuer mSelectedIssuer;
     protected PayerCost mSelectedPayerCost;
-    protected FailureRecovery mFailureRecovery;
     protected Site mSite;
 
     // Controls
@@ -59,66 +54,25 @@ public class PaymentVaultActivity extends AppCompatActivity {
 
     // Current values
     protected PaymentMethodSearch mPaymentMethodSearch;
-    protected boolean mActivityActive;
 
     // Activity parameters
-    protected String mMerchantPublicKey;
     protected BigDecimal mAmount;
-    protected String mMerchantAccessToken;
-    protected String mMerchantBaseUrl;
-    protected String mMerchantGetCustomerUri;
     protected boolean mShowBankDeals;
     protected boolean mCardGuessingEnabled;
     protected PaymentMethodSearchItem mSelectedSearchItem;
-    protected PaymentPreference mPaymentPreference;
-    protected DecorationPreference mDecorationPreference;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        getActivityParameters();
-        if(mDecorationPreference != null && mDecorationPreference.hasColors()) {
-            setTheme(R.style.Theme_MercadoPagoTheme_NoActionBar);
-        }
+    protected void setContentView() {
         setContentView(R.layout.mpsdk_activity_payment_vault);
-
-        MPTracker.getInstance().trackScreen("PAYMENT_METHOD_SEARCH", "2", mMerchantPublicKey, "MLA", "1.0", this);
-
-        setActivity();
-        mActivityActive = true;
-        boolean validParameters = true;
-
-        try {
-            validateActivityParameters();
-        } catch (IllegalStateException e) {
-            validParameters = false;
-            ErrorUtil.startErrorActivity(this, e.getMessage(), false);
-        }
-        if(validParameters) {
-
-            mMercadoPago = new MercadoPago.Builder()
-                    .setPublicKey(mMerchantPublicKey)
-                    .setContext(this)
-                    .build();
-
-            MPTracker.getInstance().trackEvent("PAYMENT_METHOD_SEARCH","INIT_PAYMENT_VAULT","2", mMerchantPublicKey, mSite.getId(), "1.0", this);
-
-            initializeToolbar();
-            initializeControls();
-
-            if (isItemSelected()) {
-                showSelectedItemChildren();
-            } else {
-                initPaymentMethodSearch();
-            }
-        }
     }
 
+    @Override
     protected void getActivityParameters() {
-
+        super.getActivityParameters();
         if (this.getIntent().getStringExtra("selectedSearchItem") != null) {
             mSelectedSearchItem = JsonUtil.getInstance().fromJson(this.getIntent().getStringExtra("selectedSearchItem"), PaymentMethodSearchItem.class);
         }
+
         try {
             mAmount = new BigDecimal(this.getIntent().getStringExtra("amount"));
         } catch (Exception ex) {
@@ -127,28 +81,25 @@ public class PaymentVaultActivity extends AppCompatActivity {
 
         mSite = JsonUtil.getInstance().fromJson(this.getIntent().getStringExtra("site"), Site.class);
 
-        mMerchantPublicKey = this.getIntent().getStringExtra("merchantPublicKey");
-
-        mMerchantBaseUrl = this.getIntent().getStringExtra("merchantBaseUrl");
-        mMerchantGetCustomerUri = this.getIntent().getStringExtra("merchantGetCustomerUri");
-        mMerchantAccessToken = this.getIntent().getStringExtra("merchantAccessToken");
         mCardGuessingEnabled = this.getIntent().getBooleanExtra("cardGuessingEnabled", false);
-        mShowBankDeals = this.getIntent().getBooleanExtra("showBankDeals", true);
 
-        if (this.getIntent().getStringExtra("paymentPreference") != null) {
-            mPaymentPreference = JsonUtil.getInstance().fromJson(this.getIntent().getStringExtra("paymentPreference"), PaymentPreference.class);
-        }
+        mShowBankDeals = this.getIntent().getBooleanExtra("showBankDeals", true);
 
         if(this.getIntent().getStringExtra("paymentMethodSearch") != null) {
             mPaymentMethodSearch = JsonUtil.getInstance().fromJson(this.getIntent().getStringExtra("paymentMethodSearch"), PaymentMethodSearch.class);
         }
-
-        if(this.getIntent().getStringExtra("decorationPreference") != null) {
-            mDecorationPreference = JsonUtil.getInstance().fromJson(this.getIntent().getStringExtra("decorationPreference"), DecorationPreference.class);
-        }
     }
 
-    private void validateActivityParameters() {
+    @Override
+    protected void initializeControls() {
+        initializeGroupRecyclerView();
+        mActivityTitle = (MPTextView) findViewById(R.id.mpsdkTitle);
+        mAppBar = (AppBarLayout) findViewById(R.id.mpsdkAppBar);
+        initializeToolbar();
+    }
+
+    @Override
+    protected void validateActivityParameters() {
 
         if(mPaymentPreference != null) {
             if (!mPaymentPreference.validMaxInstallments()) {
@@ -170,12 +121,35 @@ public class PaymentVaultActivity extends AppCompatActivity {
         }
     }
 
+    @Override
+    protected void showError(String message) {
+        ErrorUtil.startErrorActivity(this, message, false);
+    }
+
+    @Override
+    protected void onValidStart() {
+
+        mMercadoPago = new MercadoPago.Builder()
+                .setPublicKey(getMerchantPublicKey())
+                .setContext(this)
+                .build();
+
+        MPTracker.getInstance().trackScreen("PAYMENT_METHOD_SEARCH", "2", getMerchantPublicKey(), "MLA", "1.0", this);
+        MPTracker.getInstance().trackEvent("PAYMENT_METHOD_SEARCH", "INIT_PAYMENT_VAULT", "2", getMerchantPublicKey(), mSite.getId(), "1.0", this);
+
+        if (isItemSelected()) {
+            showSelectedItemChildren();
+        } else {
+            initPaymentMethodSearch();
+        }
+    }
+
     private boolean isAmountValid() {
         return mAmount != null && mAmount.compareTo(BigDecimal.ZERO) >= 0;
     }
 
     private boolean isMerchantPublicKeyValid() {
-        return mMerchantPublicKey != null;
+        return getMerchantPublicKey() != null;
     }
 
     private boolean isCurrencyIdValid() {
@@ -193,9 +167,11 @@ public class PaymentVaultActivity extends AppCompatActivity {
     private void initializeToolbar() {
         Toolbar toolbar = (Toolbar) findViewById(R.id.mpsdkToolbar);
         setSupportActionBar(toolbar);
+
         getSupportActionBar().setDisplayShowTitleEnabled(false);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setDisplayShowHomeEnabled(true);
+
         toolbar.setNavigationOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -203,35 +179,24 @@ public class PaymentVaultActivity extends AppCompatActivity {
             }
         });
 
-        if(mDecorationPreference != null) {
-            if(mDecorationPreference.hasColors()) {
-                toolbar.setBackgroundColor(mDecorationPreference.getBaseColor());
-            }
-            if(mDecorationPreference.isDarkFontEnabled()) {
-                TextView title = (TextView) findViewById(R.id.mpsdkTitle);
-                title.setTextColor(mDecorationPreference.getDarkFontColor(this));
-                Drawable upArrow = toolbar.getNavigationIcon();
-                upArrow.setColorFilter(mDecorationPreference.getDarkFontColor(this), PorterDuff.Mode.SRC_ATOP);
-                getSupportActionBar().setHomeAsUpIndicator(upArrow);
-            }
+        if(isCustomColorSet()) {
+            toolbar.setBackgroundColor(getCustomBaseColor());
         }
 
-    }
-
-    protected void initializeControls() {
-        initializeGroupRecyclerView();
-        mActivityTitle = (MPTextView) findViewById(R.id.mpsdkTitle);
-        mAppBar = (AppBarLayout) findViewById(R.id.mpsdkAppBar);
+        if(isDarkFontEnabled()) {
+            int darkFont = getDarkFontColor();
+            TextView title = (TextView) findViewById(R.id.mpsdkTitle);
+            title.setTextColor(darkFont);
+            Drawable upArrow = toolbar.getNavigationIcon();
+            upArrow.setColorFilter(darkFont, PorterDuff.Mode.SRC_ATOP);
+            getSupportActionBar().setHomeAsUpIndicator(upArrow);
+        }
     }
 
     protected void initializeGroupRecyclerView() {
         mSearchItemsRecyclerView = (RecyclerView) findViewById(R.id.mpsdkGroupsList);
         mSearchItemsRecyclerView.setHasFixedSize(true);
         mSearchItemsRecyclerView.setLayoutManager(new LinearLayoutManager(this));
-    }
-
-    protected void setActivity() {
-        this.mActivity = this;
     }
 
     private void initPaymentMethodSearch() {
@@ -264,8 +229,8 @@ public class PaymentVaultActivity extends AppCompatActivity {
 
             @Override
             public void success(PaymentMethodSearch paymentMethodSearch) {
-                MPTracker.getInstance().trackEvent("PAYMENT_METHOD_SEARCH","GET_PAYMENT_METHOD_SEARCH_RESPONSE", "SUCCESS","2", mMerchantPublicKey, mSite.getId(), "1.0", mActivity);
-                if(mActivityActive) {
+                MPTracker.getInstance().trackEvent("PAYMENT_METHOD_SEARCH","GET_PAYMENT_METHOD_SEARCH_RESPONSE", "SUCCESS","2", getMerchantPublicKey(), mSite.getId(), "1.0", getActivity());
+                if(isActivityActive()) {
                     if (!paymentMethodSearch.hasSearchItems()) {
                         showEmptyPaymentMethodsError();
                     } else {
@@ -277,15 +242,15 @@ public class PaymentVaultActivity extends AppCompatActivity {
 
             @Override
             public void failure(ApiException apiException) {
-                MPTracker.getInstance().trackEvent("PAYMENT_METHOD_SEARCH","GET_PAYMENT_METHOD_SEARCH_RESPONSE", "FAIL","2", mMerchantPublicKey, mSite.getId(), "1.0", mActivity);
-                if (mActivityActive) {
-                    ApiUtil.showApiExceptionError(mActivity, apiException);
-                    mFailureRecovery = new FailureRecovery() {
+                MPTracker.getInstance().trackEvent("PAYMENT_METHOD_SEARCH","GET_PAYMENT_METHOD_SEARCH_RESPONSE", "FAIL","2", getMerchantPublicKey(), mSite.getId(), "1.0", getActivity());
+                if (isActivityActive()) {
+                    ApiUtil.showApiExceptionError(getActivity(), apiException);
+                    setFailureRecovery(new FailureRecovery() {
                         @Override
                         public void recover() {
                             getPaymentMethodSearch();
                         }
-                    };
+                    });
                 }
             }
         });
@@ -363,17 +328,11 @@ public class PaymentVaultActivity extends AppCompatActivity {
         if(mPaymentPreference == null) {
             mPaymentPreference = new PaymentPreference();
         }
-
-        mPaymentPreference.setDefaultPaymentTypeId(item.getId());
-
-        if(mPaymentPreference == null) {
-            mPaymentPreference = new PaymentPreference();
-        }
         mPaymentPreference.setDefaultPaymentTypeId(item.getId());
 
         MercadoPago.StartActivityBuilder builder = new MercadoPago.StartActivityBuilder()
                 .setActivity(this)
-                .setPublicKey(mMerchantPublicKey)
+                .setPublicKey(getMerchantPublicKey())
                 .setPaymentPreference(mPaymentPreference)
                 .setDecorationPreference(mDecorationPreference);
 
@@ -396,7 +355,7 @@ public class PaymentVaultActivity extends AppCompatActivity {
 
     private void showRegularLayout() {
         mAppBar.setVisibility(View.VISIBLE);
-        LayoutUtil.showRegularLayout(mActivity);
+        LayoutUtil.showRegularLayout(this);
     }
 
     @Override
@@ -439,7 +398,7 @@ public class PaymentVaultActivity extends AppCompatActivity {
             finish();
         }
         else if(resultCode == RESULT_CANCELED && data != null && data.hasExtra("mpException")) {
-            MPTracker.getInstance().trackEvent("PAYMENT_VAULT","CANCELED","2",mMerchantPublicKey, mSite.getId(), "1.0",this);
+            MPTracker.getInstance().trackEvent("PAYMENT_VAULT","CANCELED","2", getMerchantPublicKey(), mSite.getId(), "1.0",this);
 
             setResult(Activity.RESULT_CANCELED, data);
             this.finish();
@@ -458,7 +417,7 @@ public class PaymentVaultActivity extends AppCompatActivity {
                 ((data != null) && (data.getStringExtra("mpException") != null))){
 
             //TODO validate
-            MPTracker.getInstance().trackEvent("PAYMENT_VAULT","CANCELED","2",mMerchantPublicKey, mSite.getId(), "1.0",this);
+            MPTracker.getInstance().trackEvent("PAYMENT_VAULT","CANCELED","2", getMerchantPublicKey(), mSite.getId(), "1.0",this);
 
             setResult(Activity.RESULT_CANCELED, data);
             this.finish();
@@ -476,7 +435,7 @@ public class PaymentVaultActivity extends AppCompatActivity {
         else {
             if ((data != null) && (data.getStringExtra("apiException") != null)) {
                 //TODO validate
-                MPTracker.getInstance().trackEvent("PAYMENT_VAULT","CANCELED","2",mMerchantPublicKey, mSite.getId(), "1.0",this);
+                MPTracker.getInstance().trackEvent("PAYMENT_VAULT","CANCELED","2", getMerchantPublicKey(), mSite.getId(), "1.0",this);
 
                 setResult(Activity.RESULT_CANCELED, data);
                 this.finish();
@@ -510,32 +469,8 @@ public class PaymentVaultActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onResume() {
-        mActivityActive = true;
-        super.onResume();
-    }
-
-    @Override
-    protected void onDestroy() {
-        mActivityActive = false;
-        super.onDestroy();
-    }
-
-    @Override
-    protected void onPause() {
-        mActivityActive = false;
-        super.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        mActivityActive = false;
-        super.onStop();
-    }
-
-    @Override
     public void onBackPressed() {
-        MPTracker.getInstance().trackEvent("PAYMENT_METHOD_SEARCH","BACK_PRESSED","2", mMerchantPublicKey, mSite.getId(), "1.0",this);
+        MPTracker.getInstance().trackEvent("PAYMENT_METHOD_SEARCH","BACK_PRESSED","2", getMerchantPublicKey(), mSite.getId(), "1.0",this);
 
         setResult(Activity.RESULT_CANCELED);
         finish();
@@ -551,11 +486,5 @@ public class PaymentVaultActivity extends AppCompatActivity {
 
     private void showEmptyPaymentMethodsError() {
         ErrorUtil.startErrorActivity(this, getString(R.string.mpsdk_no_payment_methods_found), false);
-    }
-
-    private void recoverFromFailure() {
-        if(mFailureRecovery != null) {
-            mFailureRecovery.recover();
-        }
     }
 }

--- a/sdk/src/main/java/com/mercadopago/PaymentVaultActivity.java
+++ b/sdk/src/main/java/com/mercadopago/PaymentVaultActivity.java
@@ -2,8 +2,6 @@ package com.mercadopago;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.graphics.PorterDuff;
-import android.graphics.drawable.Drawable;
 import android.support.design.widget.AppBarLayout;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;

--- a/sdk/src/main/java/com/mercadopago/PaymentVaultActivity.java
+++ b/sdk/src/main/java/com/mercadopago/PaymentVaultActivity.java
@@ -179,18 +179,10 @@ public class PaymentVaultActivity extends MercadoPagoActivity {
             }
         });
 
-        if(isCustomColorSet()) {
-            toolbar.setBackgroundColor(getCustomBaseColor());
-        }
+        TextView toolbarTitle = (TextView) findViewById(R.id.mpsdkTitle);
 
-        if(isDarkFontEnabled()) {
-            int darkFont = getDarkFontColor();
-            TextView title = (TextView) findViewById(R.id.mpsdkTitle);
-            title.setTextColor(darkFont);
-            Drawable upArrow = toolbar.getNavigationIcon();
-            upArrow.setColorFilter(darkFont, PorterDuff.Mode.SRC_ATOP);
-            getSupportActionBar().setHomeAsUpIndicator(upArrow);
-        }
+        decorate(toolbar);
+        decorate(toolbarTitle);
     }
 
     protected void initializeGroupRecyclerView() {

--- a/sdk/src/main/java/com/mercadopago/TermsAndConditionsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/TermsAndConditionsActivity.java
@@ -35,7 +35,7 @@ public class TermsAndConditionsActivity extends MercadoPagoActivity {
     }
 
     @Override
-    protected void showError(String message) {
+    protected void onInvalidStart(String message) {
         ErrorUtil.startErrorActivity(this, message, false);
     }
 

--- a/sdk/src/main/java/com/mercadopago/TermsAndConditionsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/TermsAndConditionsActivity.java
@@ -2,8 +2,6 @@ package com.mercadopago;
 
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
-import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.webkit.WebView;
@@ -13,10 +11,10 @@ import android.widget.TextView;
 
 import com.mercadopago.model.DecorationPreference;
 import com.mercadopago.mptracker.MPTracker;
-import com.mercadopago.util.JsonUtil;
+import com.mercadopago.util.ErrorUtil;
 import com.mercadopago.views.MPTextView;
 
-public class TermsAndConditionsActivity extends AppCompatActivity {
+public class TermsAndConditionsActivity extends MercadoPagoActivity {
 
     protected View mMPTermsAndConditionsView;
     protected View mBankDealsTermsAndConditionsView;
@@ -25,29 +23,20 @@ public class TermsAndConditionsActivity extends AppCompatActivity {
     protected DecorationPreference mDecorationPreference;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-
-        super.onCreate(savedInstanceState);
-        if(this.getIntent().getStringExtra("decorationPreference") != null) {
-            mDecorationPreference = JsonUtil.getInstance().fromJson(this.getIntent().getStringExtra("decorationPreference"), DecorationPreference.class);
-        }
-        if(mDecorationPreference != null && mDecorationPreference.hasColors()) {
-            setTheme(R.style.Theme_MercadoPagoTheme_NoActionBar);
-        }
-        setContentView();
-        initializeControls();
-        initializeToolbar();
-
-        // Set terms and conditions
+    protected void onValidStart() {
         if (getIntent().getStringExtra("termsAndConditions") != null) {
             mMPTermsAndConditionsView.setVisibility(View.GONE);
             showBankDealsTermsAndConditions();
         }
-        else
-        {
+        else {
             mBankDealsTermsAndConditionsView.setVisibility(View.GONE);
             showMPTermsAndConditions();
         }
+    }
+
+    @Override
+    protected void showError(String message) {
+        ErrorUtil.startErrorActivity(this, message, false);
     }
 
     private void initializeToolbar() {
@@ -62,28 +51,27 @@ public class TermsAndConditionsActivity extends AppCompatActivity {
                 onBackPressed();
             }
         });
-        if(mDecorationPreference != null) {
-            if(mDecorationPreference.hasColors()) {
-                if(toolbar != null) {
-                    decorateToolbar(toolbar);
-                }
+
+        if(isCustomColorSet()) {
+            if(toolbar != null) {
+                decorateToolbar(toolbar);
             }
-            if(mDecorationPreference.isDarkFontEnabled()) {
-                TextView title = (TextView) findViewById(R.id.mpsdkTitle);
-                title.setTextColor(mDecorationPreference.getDarkFontColor(this));
-            }
+        }
+        if(isDarkFontEnabled()) {
+            TextView title = (TextView) findViewById(R.id.mpsdkTitle);
+            title.setTextColor(getDarkFontColor());
         }
     }
 
     private void decorateToolbar(Toolbar toolbar) {
-        if(mDecorationPreference.isDarkFontEnabled()) {
+        if(isDarkFontEnabled()) {
             Drawable upArrow = toolbar.getNavigationIcon();
             if(upArrow != null) {
-                upArrow.setColorFilter(mDecorationPreference.getDarkFontColor(this), PorterDuff.Mode.SRC_ATOP);
+                upArrow.setColorFilter(getDarkFontColor(), PorterDuff.Mode.SRC_ATOP);
             }
             getSupportActionBar().setHomeAsUpIndicator(upArrow);
         }
-        toolbar.setBackgroundColor(mDecorationPreference.getLighterColor());
+        toolbar.setBackgroundColor(getCustomBaseColor());
     }
 
     private void showMPTermsAndConditions() {
@@ -118,18 +106,28 @@ public class TermsAndConditionsActivity extends AppCompatActivity {
         termsAndConditions.setText(getIntent().getStringExtra("termsAndConditions"));
     }
 
-    private void initializeControls() {
+    @Override
+    protected void initializeControls() {
         mBankDealsTermsAndConditionsView = findViewById(R.id.mpsdkBankDealsTermsAndConditions);
         mProgressbar = (ProgressBar) findViewById(R.id.mpsdkProgressBar);
         mMPTermsAndConditionsView = findViewById(R.id.mpsdkMPTermsAndConditions);
         mTermsAndConditionsWebView = (WebView) findViewById(R.id.mpsdkTermsAndConditionsWebView);
         mTermsAndConditionsWebView.setVerticalScrollBarEnabled(true);
         mTermsAndConditionsWebView.setHorizontalScrollBarEnabled(true);
+        initializeToolbar();
     }
 
+    @Override
+    protected void validateActivityParameters() throws IllegalStateException {
+        if(getIntent().getStringExtra("termsAndConditions") == null
+                && getIntent().getStringExtra("siteId") == null) {
+            throw new IllegalStateException("bank deal terms or site id required");
+        }
+    }
+
+    @Override
     protected void setContentView() {
         MPTracker.getInstance().trackScreen("TERMS_AND_CONDITIONS", "2", "publicKey", "MLA", "1.0", this);
-
         setContentView(R.layout.mpsdk_activity_terms_and_conditions);
     }
 }

--- a/sdk/src/main/java/com/mercadopago/TermsAndConditionsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/TermsAndConditionsActivity.java
@@ -1,7 +1,5 @@
 package com.mercadopago;
 
-import android.graphics.PorterDuff;
-import android.graphics.drawable.Drawable;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.webkit.WebView;
@@ -42,6 +40,8 @@ public class TermsAndConditionsActivity extends MercadoPagoActivity {
     private void initializeToolbar() {
         Toolbar toolbar = (Toolbar) findViewById(R.id.mpsdkToolbar);
         setSupportActionBar(toolbar);
+        TextView title = (TextView) findViewById(R.id.mpsdkTitle);
+
         getSupportActionBar().setDisplayShowTitleEnabled(false);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setDisplayShowHomeEnabled(true);
@@ -52,26 +52,8 @@ public class TermsAndConditionsActivity extends MercadoPagoActivity {
             }
         });
 
-        if(isCustomColorSet()) {
-            if(toolbar != null) {
-                decorateToolbar(toolbar);
-            }
-        }
-        if(isDarkFontEnabled()) {
-            TextView title = (TextView) findViewById(R.id.mpsdkTitle);
-            title.setTextColor(getDarkFontColor());
-        }
-    }
-
-    private void decorateToolbar(Toolbar toolbar) {
-        if(isDarkFontEnabled()) {
-            Drawable upArrow = toolbar.getNavigationIcon();
-            if(upArrow != null) {
-                upArrow.setColorFilter(getDarkFontColor(), PorterDuff.Mode.SRC_ATOP);
-            }
-            getSupportActionBar().setHomeAsUpIndicator(upArrow);
-        }
-        toolbar.setBackgroundColor(getCustomBaseColor());
+        decorate(toolbar);
+        decorate(title);
     }
 
     private void showMPTermsAndConditions() {

--- a/sdk/src/main/java/com/mercadopago/adapters/CustomerCardsAdapter.java
+++ b/sdk/src/main/java/com/mercadopago/adapters/CustomerCardsAdapter.java
@@ -57,8 +57,7 @@ public class CustomerCardsAdapter extends  RecyclerView.Adapter<CustomerCardsAda
     }
 
     @Override
-    public int getItemViewType(int position)
-    {
+    public int getItemViewType(int position) {
         return position;
     }
 

--- a/sdk/src/main/java/com/mercadopago/core/MercadoPago.java
+++ b/sdk/src/main/java/com/mercadopago/core/MercadoPago.java
@@ -263,7 +263,7 @@ public class MercadoPago {
     private static void startBankDealsActivity(Activity activity, String publicKey, DecorationPreference decorationPreference) {
 
         Intent bankDealsIntent = new Intent(activity, BankDealsActivity.class);
-        bankDealsIntent.putExtra("publicKey", publicKey);
+        bankDealsIntent.putExtra("merchantPublicKey", publicKey);
         bankDealsIntent.putExtra("decorationPreference", JsonUtil.getInstance().toJson(decorationPreference));
         activity.startActivityForResult(bankDealsIntent, BANK_DEALS_REQUEST_CODE);
     }

--- a/sdk/src/main/res/values/dimens.xml
+++ b/sdk/src/main/res/values/dimens.xml
@@ -23,4 +23,7 @@
     <dimen name="mpsdk_list_item_height">55dp</dimen>
     <dimen name="mpsdk_list_item_height_large">72dp</dimen>
     <dimen name="mpsdk_shopping_cart_height">120dp</dimen>
+    <!-- Default screen margins, per the Android Design guidelines. -->
+    <dimen name="activity_horizontal_margin">16dp</dimen>
+    <dimen name="activity_vertical_margin">16dp</dimen>
 </resources>


### PR DESCRIPTION
@valeserber @MatiasRomar @matiasgualino Les pido si pueden ver bien en detalle este PR, y vean si tienen alguna idea o feedback para sumar a esto. 

La intención es que todas las Activities de la SDK hereden de esta clase abstracta, así que les cuento un poco qué ganaríamos. Se usa en esta branch en PaymentMethodsActivity, PaymentVaultActivity, CheckoutActivity, InstructionsActivity, TermsAndConditionsActivity y BankDealsActivity.

**Responsabilidades que toma MercadoPagoActivity:**

- Conocimiento de si una Activity está activa: hasta ahora tenemos un flag en cada Activity "mActiveActivity", y lo seteamos en los métodos onResume, onPause, etc de c/u. Ahora sólo se hace en MercadoPagoActivity, que cuenta con un método **isActivityActive()**.

- Manejo de recupero de errores: actualmente tenemos una interfaz FailureRecovery, que en cada api call se implementa con su método "recover", que se llama cuando el usuario toca "Reintentar".
Para esto, tenemos un atributo del tipo de esta interfaz en cada Activity, y un método "recover()" que chequea que se haya implementado la interfaz y llama al método recover() de la misma.
MercadoPagoActivity cuenta con un método "setFailureRecovery(...)" y un método "recover()" que se encargan de todo esto, y nos ahorra la implementación en cada pantalla.

- Seteo de atributos comunes:
MercadoPagoActivity va a tener (si se mandan) los atributos:
   
>    merchantPublicKey
>     merchantBaseUrl
>     merchantGetCustomerUri
>     merchantCreatePaymentUri
>     merchantAccessToken
>     decorationPreference
>     paymentPreference

- Estandarización de cómo obtenemos parámetros, inicializamos controladores y los validamos: el método onCreate de MercadoPagoActivity tiene esta lógica:

```
if(mDecorationPreference != null && mDecorationPreference.hasColors()) {
            setTheme(R.style.Theme_MercadoPagoTheme_NoActionBar);
}
setActivity();
mActivityActive = true;
*setContentView();*
*getActivityParameters();*
try {
       *validateActivityParameters();*
       *initializeControls();*
       *onValidStart();*
} catch (IllegalStateException exception) {
       *showError(exception.getMessage());*
}

```

Los métodos entre ** los tenemos que implementar en cada activity. Son todos abstractos menos  **getActivityParameters();**, que obtiene los datos comunes que listé antes. Tenemos que hacer un Override de este método y llamar al super.getActivityParameters() (lo va a pedir el compilador).

Entonces, todas nuestras Activities quedarían _**sin el onCreate()**_ . Con estos métodos preparamos la Activity, y en el **onValidStart()** iniciamos el flujo normal de la Activity.

Creo que es algo que nos puede ayudar tanto a nosotros como a los integradores que lean nuestro código, ya que no se encuentran con cosas distintas hasta que ver lógica propia de cada pantalla.