### PR TITLE
Fixed mocked api framework

### DIFF
--- a/sdk/src/androidTest/java/com/mercadopago/CheckoutActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/CheckoutActivityTest.java
@@ -153,8 +153,6 @@ public class CheckoutActivityTest {
         //Validations
         String comment = paymentMethodSearch.getSearchItemByPaymentMethod(paymentMethod).getComment();
 
-        onView(withId(R.id.contentLayout))
-                .check(matches(isDisplayed()));
         onView(withId(R.id.mpsdkComment))
                 .check(matches(withText(comment)));
 
@@ -185,6 +183,11 @@ public class CheckoutActivityTest {
         mTestRule.addApiResponseToQueue(paymentMethodSearchJson, 200, "");
 
         mTestRule.launchActivity(validStartIntent);
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         //perform actions
         mTestRule.restartIntents();
         onView(withId(R.id.mpsdkEditHint)).perform(click());
@@ -221,12 +224,10 @@ public class CheckoutActivityTest {
         //Validations
         String comment = paymentMethodSearch.getSearchItemByPaymentMethod(paymentMethod).getComment();
 
-        onView(withId(R.id.contentLayout))
-                .check(matches(isDisplayed()));
         onView(withId(R.id.mpsdkComment))
                 .check(matches(withText(comment)));
 
-        ImageView paymentMethodImage = (ImageView) activity.findViewById(R.id.image);
+        ImageView paymentMethodImage = (ImageView) activity.findViewById(R.id.mpsdkImage);
 
         Bitmap bitmap = ((BitmapDrawable) paymentMethodImage.getDrawable()).getBitmap();
         Bitmap bitmap2 = ((BitmapDrawable) ContextCompat.getDrawable(activity, R.drawable.oxxo)).getBitmap();

--- a/sdk/src/androidTest/java/com/mercadopago/InstructionsActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/InstructionsActivityTest.java
@@ -19,6 +19,7 @@ import com.mercadopago.util.JsonUtil;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -83,7 +84,7 @@ public class InstructionsActivityTest {
         Instruction instructionWithoutActions = StaticMock.getInstructionWithoutActions();
         mTestRule.addApiResponseToQueue(instructionWithoutActions, 200, "");
         mTestRule.launchActivity(validStartIntent);
-        onView(withId(R.id.title)).check(matches(withText(instructionWithoutActions.getTitle())));
+        onView(withId(R.id.mpsdkTitle)).check(matches(withText(instructionWithoutActions.getTitle())));
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/mercadopago/test/FakeAPI.java
+++ b/sdk/src/androidTest/java/com/mercadopago/test/FakeAPI.java
@@ -1,0 +1,65 @@
+package com.mercadopago.test;
+
+import com.mercadopago.util.JsonUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by mreverter on 1/7/16.
+ */
+public class FakeAPI {
+
+    private static List<QueuedResponse> queuedResponses;
+
+    public static QueuedResponse getNextResponse() {
+
+        if(queuedResponses != null && !queuedResponses.isEmpty()) {
+            return queuedResponses.remove(0);
+        }
+        else {
+            return new QueuedResponse("", 401, "");
+        }
+    }
+
+    public static <T> void addResponseToQueue(T response, int statusCode, String reason) {
+        if(queuedResponses == null) {
+            queuedResponses = new ArrayList<>();
+        }
+        String jsonResponse = JsonUtil.getInstance().toJson(response);
+        QueuedResponse queuedResponse = new QueuedResponse(jsonResponse, statusCode, reason);
+        queuedResponses.add(queuedResponse);
+    }
+
+    public static void addResponseToQueue(String jsonResponse, int statusCode, String reason) {
+        if(queuedResponses == null) {
+            queuedResponses = new ArrayList<>();
+        }
+        QueuedResponse queuedResponse = new QueuedResponse(jsonResponse, statusCode, reason);
+        queuedResponses.add(queuedResponse);
+    }
+
+    public static void cleanQueue() {
+        queuedResponses.clear();
+    }
+
+    public static class QueuedResponse {
+        private String jsonResponse;
+        private int statusCode;
+        private String reason;
+
+        public QueuedResponse(String jsonResponse, int statusCode, String reason) {
+            this.jsonResponse = jsonResponse;
+            this.reason = reason;
+            this.statusCode = statusCode;
+        }
+
+        public String getBodyAsJson() {
+            return jsonResponse;
+        }
+
+        public int getStatusCode() {
+            return statusCode;
+        }
+    }
+}

--- a/sdk/src/androidTest/java/com/mercadopago/test/FakeAPI.java
+++ b/sdk/src/androidTest/java/com/mercadopago/test/FakeAPI.java
@@ -27,8 +27,7 @@ public class FakeAPI {
             queuedResponses = new ArrayList<>();
         }
         String jsonResponse = JsonUtil.getInstance().toJson(response);
-        QueuedResponse queuedResponse = new QueuedResponse(jsonResponse, statusCode, reason);
-        queuedResponses.add(queuedResponse);
+        addResponseToQueue(jsonResponse, statusCode, reason);
     }
 
     public static void addResponseToQueue(String jsonResponse, int statusCode, String reason) {

--- a/sdk/src/androidTest/java/com/mercadopago/test/FakeInterceptor.java
+++ b/sdk/src/androidTest/java/com/mercadopago/test/FakeInterceptor.java
@@ -1,10 +1,6 @@
 package com.mercadopago.test;
 
-import com.mercadopago.util.JsonUtil;
-
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
@@ -17,20 +13,14 @@ import okhttp3.ResponseBody;
  */
 public class FakeInterceptor implements Interceptor {
 
-    private List<QueuedResponse> queuedResponses;
-
-    public FakeInterceptor() {
-        queuedResponses = new ArrayList<>();
-    }
-
     @Override
     public Response intercept(Chain chain) throws IOException {
         Response response = null;
         if(BuildConfig.DEBUG) {
-            QueuedResponse nextResponse = getNextResponse();
-            String responseString = nextResponse.jsonResponse;
+            FakeAPI.QueuedResponse nextResponse = FakeAPI.getNextResponse();
+            String responseString = nextResponse.getBodyAsJson();
             response = new Response.Builder()
-                    .code(nextResponse.statusCode)
+                    .code(nextResponse.getStatusCode())
                     .message(responseString)
                     .request(chain.request())
                     .protocol(Protocol.HTTP_1_0)
@@ -43,42 +33,5 @@ public class FakeInterceptor implements Interceptor {
         }
 
         return response;
-    }
-
-    private QueuedResponse getNextResponse() {
-
-        if(!queuedResponses.isEmpty()) {
-            return queuedResponses.remove(0);
-        }
-        else {
-            return new QueuedResponse("", 401, "");
-        }
-    }
-
-    public <T> void addResponseToQueue(T response, int statusCode, String reason) {
-        String jsonResponse = JsonUtil.getInstance().toJson(response);
-        QueuedResponse queuedResponse = new QueuedResponse(jsonResponse, statusCode, reason);
-        this.queuedResponses.add(queuedResponse);
-    }
-
-    public void addResponseToQueue(String jsonResponse, int statusCode, String reason) {
-        QueuedResponse queuedResponse = new QueuedResponse(jsonResponse, statusCode, reason);
-        this.queuedResponses.add(queuedResponse);
-    }
-
-    public void cleanQueue() {
-        this.queuedResponses.clear();
-    }
-
-    private class QueuedResponse {
-        private String jsonResponse;
-        private int statusCode;
-        private String reason;
-
-        public QueuedResponse(String jsonResponse, int statusCode, String reason) {
-            this.jsonResponse = jsonResponse;
-            this.reason = reason;
-            this.statusCode = statusCode;
-        }
     }
 }

--- a/sdk/src/androidTest/java/com/mercadopago/test/rules/MockedApiTestRule.java
+++ b/sdk/src/androidTest/java/com/mercadopago/test/rules/MockedApiTestRule.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.support.test.espresso.intent.Intents;
 import android.support.test.rule.ActivityTestRule;
 
+import com.mercadopago.test.FakeAPI;
 import com.mercadopago.test.FakeInterceptor;
 import com.mercadopago.util.HttpClientUtil;
 import com.mercadopago.util.JsonUtil;
@@ -22,33 +23,33 @@ public class MockedApiTestRule<A extends Activity> extends ActivityTestRule<A> {
     public MockedApiTestRule(Class<A> activityClass) {
         super(activityClass);
         intentsActive = false;
-        setUpMockedClient();
+        setUpFakeInterceptor();
     }
 
     public MockedApiTestRule(Class<A> activityClass, boolean initialTouchMode) {
         super(activityClass, initialTouchMode);
         intentsActive = false;
-        setUpMockedClient();
+        setUpFakeInterceptor();
     }
 
     public MockedApiTestRule(Class<A> activityClass, boolean initialTouchMode, boolean launchActivity) {
         super(activityClass, initialTouchMode, launchActivity);
         intentsActive = false;
-        setUpMockedClient();
+        setUpFakeInterceptor();
     }
 
-    private void setUpMockedClient() {
+    private void setUpFakeInterceptor() {
         fakeInterceptor = new FakeInterceptor();
         HttpClientUtil.bindInterceptor(fakeInterceptor);
     }
 
     public <T> void addApiResponseToQueue(T response, int statusCode, String reason) {
         String jsonResponse = JsonUtil.getInstance().toJson(response);
-        fakeInterceptor.addResponseToQueue(jsonResponse, statusCode, reason);
+        FakeAPI.addResponseToQueue(jsonResponse, statusCode, reason);
     }
 
     public void addApiResponseToQueue(String jsonResponse, int statusCode, String reason) {
-        fakeInterceptor.addResponseToQueue(jsonResponse, statusCode, reason);
+        FakeAPI.addResponseToQueue(jsonResponse, statusCode, reason);
     }
 
     @Override
@@ -65,7 +66,7 @@ public class MockedApiTestRule<A extends Activity> extends ActivityTestRule<A> {
         if(intentsActive) {
             this.releaseIntents();
         }
-        fakeInterceptor.cleanQueue();
+        FakeAPI.cleanQueue();
     }
 
     public void initIntentsRecording() {

--- a/sdk/src/main/java/com/mercadopago/CheckoutActivity.java
+++ b/sdk/src/main/java/com/mercadopago/CheckoutActivity.java
@@ -90,7 +90,6 @@ public class CheckoutActivity extends AppCompatActivity {
     protected MPTextView mCancelTextView;
     protected MPTextView mTotalAmountTextView;
     protected MPButton mPayButton;
-    protected View mContentView;
     protected RelativeLayout mPaymentMethodLayout;
     protected RelativeLayout mPayerCostLayout;
     protected Boolean mBackPressedOnce;
@@ -295,7 +294,6 @@ public class CheckoutActivity extends AppCompatActivity {
         }
 
         mTotalAmountTextView = (MPTextView) findViewById(R.id.mpsdkTotalAmountText);
-        mContentView = findViewById(R.id.mpsdkContentLayout);
         mPaymentMethodLayout = (RelativeLayout) findViewById(R.id.mpsdkPaymentMethodLayout);
         mPayerCostLayout = (RelativeLayout) findViewById(R.id.mpsdkPayerCostLayout);
     }

--- a/sdk/src/main/res/layout/mpsdk_content_checkout.xml
+++ b/sdk/src/main/res/layout/mpsdk_content_checkout.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.NestedScrollView
-        android:id="@+id/contentLayout"
+        android:id="@+id/mpsdkContentLayout"
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"


### PR DESCRIPTION
Se corrige el problema de que no corrían todos los tests juntos (sí por separado).

¿Qué pasaba? Para mockear la api estoy agregando un Interceptor, que tenía una lista de respuestas, que iban cambiando según el test. OkHttp internamente utiliza el método

Util.immutableList(builder.interceptors);

Por lo que la lista de interceptors cambia, y aunque agregue respuestas en la original no se modifica la actual.

Para evitar esto, un workaround fue crear una clase FakeAPI que contenga las respuestas, y el interceptor acceda a ellas estáticamente.



