### PR TITLE
Refactor guessing con MercadoPagoActivity

### DIFF
--- a/sdk/src/main/java/com/mercadopago/FrontCardActivity.java
+++ b/sdk/src/main/java/com/mercadopago/FrontCardActivity.java
@@ -1,12 +1,11 @@
 package com.mercadopago;
 
-import android.support.v7.app.AppCompatActivity;
 
 import com.mercadopago.model.PaymentMethod;
 
 import java.util.Locale;
 
-public abstract class FrontCardActivity extends AppCompatActivity implements CardInterface {
+public abstract class FrontCardActivity extends MercadoPagoActivity implements CardInterface {
 
     protected String mCardNumber;
     protected String mCardHolderName;

--- a/sdk/src/main/java/com/mercadopago/MercadoPagoActivity.java
+++ b/sdk/src/main/java/com/mercadopago/MercadoPagoActivity.java
@@ -34,6 +34,7 @@ public abstract class MercadoPagoActivity extends AppCompatActivity {
         try {
             validateActivityParameters();
             initializeControls();
+            initializeFragments(savedInstanceState);
             onValidStart();
         } catch (IllegalStateException exception) {
             onInvalidStart(exception.getMessage());
@@ -59,6 +60,10 @@ public abstract class MercadoPagoActivity extends AppCompatActivity {
     protected abstract void onValidStart();
 
     protected abstract void onInvalidStart(String message);
+
+    protected void initializeFragments(Bundle savedInstanceState) {
+
+    }
 
     private void getDecorationPreference() {
         if(getIntent().getStringExtra("decorationPreference") != null) {

--- a/sdk/src/main/java/com/mercadopago/ShowCardActivity.java
+++ b/sdk/src/main/java/com/mercadopago/ShowCardActivity.java
@@ -2,7 +2,6 @@ package com.mercadopago;
 
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
-import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.widget.FrameLayout;
@@ -10,7 +9,6 @@ import android.widget.FrameLayout;
 import com.mercadopago.core.MercadoPago;
 import com.mercadopago.fragments.CardFrontFragment;
 import com.mercadopago.model.Cardholder;
-import com.mercadopago.model.DecorationPreference;
 import com.mercadopago.model.Issuer;
 import com.mercadopago.model.PaymentMethod;
 import com.mercadopago.model.Setting;
@@ -42,13 +40,6 @@ public abstract class ShowCardActivity extends FrontCardActivity {
     //Local vars
     protected Issuer mSelectedIssuer;
     protected MPTextView mToolbarTitle;
-    protected DecorationPreference mDecorationPreference;
-
-
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
 
     protected abstract void finishWithResult();
 
@@ -59,10 +50,6 @@ public abstract class ShowCardActivity extends FrontCardActivity {
         mToken = JsonUtil.getInstance().fromJson(
                 this.getIntent().getStringExtra("token"), Token.class);
         mSelectedIssuer = JsonUtil.getInstance().fromJson(this.getIntent().getStringExtra("issuer"), Issuer.class);
-
-        if(this.getIntent().getStringExtra("decorationPreference") != null) {
-            mDecorationPreference = JsonUtil.getInstance().fromJson(this.getIntent().getStringExtra("decorationPreference"), DecorationPreference.class);
-        }
 
         if(mToken != null) {
             setCardInfo();


### PR DESCRIPTION
- GuessingCardActivity, CardVaultActivity, InstallmentsActivity & IssuersActivity, ahora extienden indirectamente de MercadoPagoActivity.
- Se agregó el método initializeFragments en MercadoPagoActivity, dentro del OnCreate, para que lo implementen las subclases que deseen.