### PR TITLE
PaymentMethodSearch refactor

### DIFF
--- a/sdk/src/androidTest/java/com/mercadopago/model/PaymentMethodSearchGetPaymentMethodTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/model/PaymentMethodSearchGetPaymentMethodTest.java
@@ -22,11 +22,11 @@ public class PaymentMethodSearchGetPaymentMethodTest {
     return Arrays.asList(new Object[][]{
                 {"oxxo", "oxxo", "ticket"},
                 {"bancomer_bank_transfer", "bancomer", "bank_transfer"},
-                {"bancomer_ticket", "bancomer", "ticket"},
-                {"banamex_bank_transfer", "banamex", "bank_transfer"},
+                {"bancomer.ticket", "bancomer", "ticket"},
+                {"banamex.bank_transfer", "banamex", "bank_transfer"},
                 {"banamex_ticket", "banamex", "ticket"},
                 {"serfin_bank_transfer", "serfin", "bank_transfer"},
-                {"serfin_ticket", "serfin", "ticket"},
+                {"serfin.ticket", "serfin", "ticket"},
                 {"invalid_item", "invalid_item", ""}
         });
     }

--- a/sdk/src/androidTest/java/com/mercadopago/model/PaymentMethodSearchGetPaymentMethodTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/model/PaymentMethodSearchGetPaymentMethodTest.java
@@ -62,7 +62,6 @@ public class PaymentMethodSearchGetPaymentMethodTest {
         }
     }
 
-
     private PaymentMethodSearch getPaymentMethodSearch() {
         String paymentMethodSearchJson = StaticMock.getCompletePaymentMethodSearchAsJson();
         return JsonUtil.getInstance().fromJson(paymentMethodSearchJson, PaymentMethodSearch.class);

--- a/sdk/src/main/java/com/mercadopago/model/PaymentMethodSearch.java
+++ b/sdk/src/main/java/com/mercadopago/model/PaymentMethodSearch.java
@@ -71,22 +71,29 @@ public class PaymentMethodSearch {
     }
 
     private PaymentMethodSearchItem searchItemMatchingPaymentMethod(PaymentMethod paymentMethod) {
-        String potentialItemId = paymentMethod.getId() + "_" + paymentMethod.getPaymentTypeId();
-        String paymentMethodId = paymentMethod.getId();
-        return searchItemInList(groups, potentialItemId, paymentMethodId);
+        return searchItemInList(groups, paymentMethod);
     }
 
-    private PaymentMethodSearchItem searchItemInList(List<PaymentMethodSearchItem> list, String potentialItemId, String paymentMethodId) {
+    private PaymentMethodSearchItem searchItemInList(List<PaymentMethodSearchItem> list, PaymentMethod paymentMethod) {
         PaymentMethodSearchItem requiredItem = null;
         for(PaymentMethodSearchItem currentItem : list) {
 
-            if(currentItem.getId().equals(paymentMethodId)
-                    || currentItem.getId().equals(potentialItemId)) {
+            //Case like "pagofacil", without the payment type in the item id.
+            if(itemMatchesPaymentMethod(currentItem, paymentMethod) && currentItem.getId().equals(paymentMethod.getId())) {
                 requiredItem = currentItem;
                 break;
             }
+            //Case like "bancomer_ticker", with the payment type in the item id
+            else if(itemMatchesPaymentMethod(currentItem, paymentMethod)) {
+                //Remove payment method id from item id
+                String potentialPaymentType = currentItem.getId().replace(paymentMethod.getId(), "");
+                if(potentialPaymentType.endsWith(paymentMethod.getPaymentTypeId())) {
+                    requiredItem = currentItem;
+                    break;
+                }
+            }
             else if(currentItem.hasChildren()) {
-                requiredItem = searchItemInList(currentItem.getChildren(), potentialItemId, paymentMethodId);
+                requiredItem = searchItemInList(currentItem.getChildren(), paymentMethod);
                 if(requiredItem != null) {
                     break;
                 }

--- a/sdk/src/main/java/com/mercadopago/model/PaymentMethodSearch.java
+++ b/sdk/src/main/java/com/mercadopago/model/PaymentMethodSearch.java
@@ -20,6 +20,7 @@ public class PaymentMethodSearch {
     public List<PaymentMethod> getPaymentMethods() {
         return paymentMethods;
     }
+
     public boolean hasSearchItems() {
         return this.groups != null && !this.groups.isEmpty();
     }
@@ -28,19 +29,35 @@ public class PaymentMethodSearch {
         PaymentMethod requiredPaymentMethod = null;
         if(paymentMethods != null && item != null && item.getId() != null) {
             for (PaymentMethod currentPaymentMethod : paymentMethods) {
-                if (item.getId().contains(currentPaymentMethod.getId())) {
+                if (itemMatchesPaymentMethod(item, currentPaymentMethod)) {
                     requiredPaymentMethod = currentPaymentMethod;
-
-                    String itemPaymentType = item.getId().replace(currentPaymentMethod.getId() + "_", "");
-                    if(PaymentTypes.getAllPaymentTypes().contains(itemPaymentType)) {
-                        //MP API v1 not contemplating different payment types for a payment method. Overriding to give consistent instructions.
-                        requiredPaymentMethod.setPaymentTypeId(itemPaymentType);
-                    }
-                    break;
+                    requiredPaymentMethod.setPaymentTypeId(getPaymentTypeIdFromItem(item, currentPaymentMethod));
                 }
             }
         }
         return requiredPaymentMethod;
+    }
+
+    private String getPaymentTypeIdFromItem(PaymentMethodSearchItem item, PaymentMethod paymentMethod) {
+
+        String paymentType = "";
+
+        //Remove payment method id from item id
+        String potentialPaymentType = item.getId().replace(paymentMethod.getId(), "");
+        for(String currentPaymentType : PaymentTypes.getAllPaymentTypes()) {
+            if(potentialPaymentType.endsWith(currentPaymentType)){
+                paymentType = currentPaymentType;
+                break;
+            }
+        }
+        if(paymentType.isEmpty()) {
+            paymentType = paymentMethod.getPaymentTypeId();
+        }
+        return paymentType;
+    }
+
+    private boolean itemMatchesPaymentMethod(PaymentMethodSearchItem item, PaymentMethod paymentMethod) {
+        return item.getId().startsWith(paymentMethod.getId());
     }
 
     public PaymentMethodSearchItem getSearchItemByPaymentMethod(PaymentMethod selectedPaymentMethod) {
@@ -59,7 +76,6 @@ public class PaymentMethodSearch {
         return searchItemInList(groups, potentialItemId, paymentMethodId);
     }
 
-    //PaymentMethodSearchItem id could be the payment method id or its concatenation with the paymentTypeId
     private PaymentMethodSearchItem searchItemInList(List<PaymentMethodSearchItem> list, String potentialItemId, String paymentMethodId) {
         PaymentMethodSearchItem requiredItem = null;
         for(PaymentMethodSearchItem currentItem : list) {


### PR DESCRIPTION
Se refactorizó la forma en que se obtiene el PaymentMethod correspondiente con el PaymentTypeId que se incluye en el  id del item, dado un PaymentMethodSearchItem que el usuario selecciona.

También el método que dado un medio de pago, obtiene el item correspondiente del los que se encuentran en la respuesta del servicio. 

De la nueva forma, no dependemos de cómo se separe en backend el id del medio de pago, del del tipo de medio de pago:

"bancomer_bank_transfer" o bancomer.bank_transfer" funcionan.

Se modificaron los test cases correspondientes.

A su vez, se emprolijó el código.
