### PR TITLE
Se agregan tests de TermsAndConditionsActivity

### DIFF
--- a/sdk/src/androidTest/java/com/mercadopago/BankDealsActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/BankDealsActivityTest.java
@@ -105,7 +105,7 @@ public class BankDealsActivityTest {
 
         String legals = bankDeals.get(0).getLegals();
 
-        intended(allOf(hasComponent(TermsAndConditionsActivity.class.getName()), hasExtra("termsAndConditions", legals)));
+        intended(allOf(hasComponent(TermsAndConditionsActivity.class.getName()), hasExtra("bankDealLegals", legals)));
     }
 
     //Initial validations

--- a/sdk/src/androidTest/java/com/mercadopago/TermsAndConditionsActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/TermsAndConditionsActivityTest.java
@@ -1,0 +1,158 @@
+package com.mercadopago;
+
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.NoActivityResumedException;
+import android.support.test.espresso.intent.Intents;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v4.content.ContextCompat;
+import android.test.suitebuilder.annotation.LargeTest;
+import android.view.View;
+
+import com.mercadopago.constants.Sites;
+import com.mercadopago.model.DecorationPreference;
+import com.mercadopago.test.StaticMock;
+import com.mercadopago.util.JsonUtil;
+import com.mercadopago.utils.ViewUtils;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.pressBack;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.intent.Intents.intended;
+import static android.support.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by mreverter on 21/7/16.
+ */
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class TermsAndConditionsActivityTest  {
+
+    @Rule
+    public ActivityTestRule<TermsAndConditionsActivity> mTestRule = new ActivityTestRule<>(TermsAndConditionsActivity.class, true, false);
+
+    @Before
+    public void initIntents() {
+        Intents.init();
+    }
+
+    @After
+    public void releaseIntents() {
+        Intents.release();
+    }
+
+    //Validation
+
+    @Test
+    public void ifNeitherLegalsNorSiteReceivedStartErrorActivity() {
+        Intent invalidStartIntent =  new Intent();
+        mTestRule.launchActivity(invalidStartIntent);
+
+        intended(hasComponent(ErrorActivity.class.getName()));
+    }
+
+    //Bank deals legals
+
+    @Test
+    public void ifBankDealsLegalsReceivedShowThem() {
+        String legals = StaticMock.getBankDeals().get(0).getLegals();
+
+        Intent legalsIntent =  new Intent();
+        legalsIntent.putExtra("bankDealLegals", legals);
+
+        mTestRule.launchActivity(legalsIntent);
+
+        assertTrue(legals.equals(mTestRule.getActivity().mBankDealsLegalsTextView.getText()));
+    }
+
+    //MercadoPagoTermsAndConditions
+
+    @Test
+    public void ifMLASiteReceivedShowMercadoPagoTermsAndConditions() {
+        Intent mlaIntent = new Intent();
+        mlaIntent.putExtra("siteId", Sites.ARGENTINA.getId());
+
+        mTestRule.launchActivity(mlaIntent);
+
+        assertTrue(mTestRule.getActivity().mTermsAndConditionsWebView.getVisibility() == View.VISIBLE);
+    }
+
+    @Test
+    public void ifMLMSiteReceivedShowMercadoPagoTermsAndConditions() {
+        Intent mlmIntent = new Intent();
+        mlmIntent.putExtra("siteId", Sites.MEXICO.getId());
+
+        mTestRule.launchActivity(mlmIntent);
+
+        assertTrue(mTestRule.getActivity().mTermsAndConditionsWebView.getVisibility() == View.VISIBLE);
+    }
+
+    @Test
+    public void ifNeitherMLANorMLMSiteReceivedFinishActivity() {
+        Intent mlmIntent = new Intent();
+        mlmIntent.putExtra("siteId", Sites.BRASIL.getId());
+
+        mTestRule.launchActivity(mlmIntent);
+
+        assertTrue(mTestRule.getActivity().isFinishing());
+    }
+
+    //On back pressed finish activity
+
+    @Test (expected = NoActivityResumedException.class)
+    public void onBackPressedFinishActivity () {
+        String legals = StaticMock.getBankDeals().get(0).getLegals();
+
+        Intent legalsIntent =  new Intent();
+        legalsIntent.putExtra("bankDealLegals", legals);
+
+        mTestRule.launchActivity(legalsIntent);
+
+        pressBack();
+    }
+
+    @Test
+    public void onNavigationArrowPressedFinishActivity () {
+        String legals = StaticMock.getBankDeals().get(0).getLegals();
+
+        Intent legalsIntent =  new Intent();
+        legalsIntent.putExtra("bankDealLegals", legals);
+
+        mTestRule.launchActivity(legalsIntent);
+
+        onView(withContentDescription(R.string.abc_action_bar_up_description)).perform(click());
+
+        assertTrue(mTestRule.getActivity().isFinishing());
+    }
+
+    //Decoration
+
+    @Test
+    public void onDecorationPreferenceSetWithBaseColorAndDarkFontEnabledDecorateToolbar() {
+        DecorationPreference decorationPreference = new DecorationPreference();
+        decorationPreference.enableDarkFont();
+        decorationPreference.setBaseColor(ContextCompat.getColor(InstrumentationRegistry.getContext(), R.color.mpsdk_color_light_grey));
+
+        String legals = StaticMock.getBankDeals().get(0).getLegals();
+
+        Intent legalsIntent =  new Intent();
+        legalsIntent.putExtra("bankDealLegals", legals);
+        legalsIntent.putExtra("decorationPreference", JsonUtil.getInstance().toJson(decorationPreference));
+
+        mTestRule.launchActivity(legalsIntent);
+
+        Assert.assertTrue(ViewUtils.getBackgroundColor(mTestRule.getActivity().mToolbar) == decorationPreference.getBaseColor());
+        Assert.assertTrue(mTestRule.getActivity().mTitle.getCurrentTextColor() == decorationPreference.getDarkFontColor(mTestRule.getActivity()));
+    }
+
+}

--- a/sdk/src/main/java/com/mercadopago/BankDealsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/BankDealsActivity.java
@@ -109,7 +109,7 @@ public class BankDealsActivity extends MercadoPagoActivity {
                     public void onClick(View view) {
                         BankDeal selectedBankDeal = (BankDeal) view.getTag();
                         Intent intent = new Intent(getActivity(), TermsAndConditionsActivity.class);
-                        intent.putExtra("termsAndConditions", selectedBankDeal.getLegals());
+                        intent.putExtra("bankDealLegals", selectedBankDeal.getLegals());
                         startActivity(intent);
                     }
                 }));

--- a/sdk/src/main/java/com/mercadopago/TermsAndConditionsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/TermsAndConditionsActivity.java
@@ -20,20 +20,24 @@ public class TermsAndConditionsActivity extends MercadoPagoActivity {
     protected View mBankDealsTermsAndConditionsView;
     protected WebView mTermsAndConditionsWebView;
     protected ProgressBar mProgressbar;
+    protected MPTextView mBankDealsLegalsTextView;
+    protected Toolbar mToolbar;
+    protected TextView mTitle;
+
     protected DecorationPreference mDecorationPreference;
     protected String mBankDealsTermsAndConditions;
     protected String mSiteId;
 
     @Override
     protected void getActivityParameters() {
-        mBankDealsTermsAndConditions = getIntent().getStringExtra("termsAndConditions");
+        mBankDealsTermsAndConditions = getIntent().getStringExtra("bankDealLegals");
         mSiteId = getIntent().getStringExtra("siteId");
     }
 
     @Override
     protected void validateActivityParameters() throws IllegalStateException {
-        if(getIntent().getStringExtra("termsAndConditions") == null
-                && getIntent().getStringExtra("siteId") == null) {
+        if(mBankDealsTermsAndConditions == null
+                && mSiteId == null) {
             throw new IllegalStateException("bank deal terms or site id required");
         }
     }
@@ -50,6 +54,7 @@ public class TermsAndConditionsActivity extends MercadoPagoActivity {
         mProgressbar = (ProgressBar) findViewById(R.id.mpsdkProgressBar);
         mMPTermsAndConditionsView = findViewById(R.id.mpsdkMPTermsAndConditions);
         mTermsAndConditionsWebView = (WebView) findViewById(R.id.mpsdkTermsAndConditionsWebView);
+        mBankDealsLegalsTextView = (MPTextView) findViewById(R.id.mpsdkTermsAndConditions);
         mTermsAndConditionsWebView.setVerticalScrollBarEnabled(true);
         mTermsAndConditionsWebView.setHorizontalScrollBarEnabled(true);
         initializeToolbar();
@@ -57,22 +62,22 @@ public class TermsAndConditionsActivity extends MercadoPagoActivity {
 
 
     private void initializeToolbar() {
-        Toolbar toolbar = (Toolbar) findViewById(R.id.mpsdkToolbar);
-        setSupportActionBar(toolbar);
-        TextView title = (TextView) findViewById(R.id.mpsdkTitle);
+        mToolbar = (Toolbar) findViewById(R.id.mpsdkToolbar);
+        setSupportActionBar(mToolbar);
+        mTitle = (TextView) findViewById(R.id.mpsdkTitle);
 
         getSupportActionBar().setDisplayShowTitleEnabled(false);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setDisplayShowHomeEnabled(true);
-        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+        mToolbar.setNavigationOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 onBackPressed();
             }
         });
 
-        decorate(toolbar);
-        decorate(title);
+        decorate(mToolbar);
+        decorate(mTitle);
     }
 
     @Override
@@ -89,36 +94,29 @@ public class TermsAndConditionsActivity extends MercadoPagoActivity {
 
     @Override
     protected void onInvalidStart(String message) {
-        ErrorUtil.startErrorActivity(this, message, false);
+        ErrorUtil.startErrorActivity(this, getString(R.string.mpsdk_standard_error_message), message, false);
     }
 
     private void showMPTermsAndConditions() {
-        if (mProgressbar != null) {
-            mProgressbar.setVisibility(View.VISIBLE);
+        mProgressbar.setVisibility(View.VISIBLE);
+        mTermsAndConditionsWebView.setWebViewClient(new WebViewClient() {
+            public void onPageFinished(WebView view, String url) {
+                mProgressbar.setVisibility(View.GONE);
+                mMPTermsAndConditionsView.setVisibility(View.VISIBLE);
+            }
+        });
+        if(mSiteId.equals("MLA")) {
+            mTermsAndConditionsWebView.loadUrl("https://www.mercadopago.com.ar/ayuda/terminos-y-condiciones_299");
         }
-        if(mSiteId != null) {
-            mTermsAndConditionsWebView.setWebViewClient(new WebViewClient() {
-                public void onPageFinished(WebView view, String url) {
-                    mProgressbar.setVisibility(View.GONE);
-                    mMPTermsAndConditionsView.setVisibility(View.VISIBLE);
-                }
-            });
-            if(mSiteId.equals("MLA")) {
-                mTermsAndConditionsWebView.loadUrl("https://www.mercadopago.com.ar/ayuda/terminos-y-condiciones_299");
-            }
-            else if (mSiteId.equals("MLM")){
-                mTermsAndConditionsWebView.loadUrl("https://www.mercadopago.com.mx/ayuda/terminos-y-condiciones_715");
-            }
-            else {
-                finish();
-            }
-        } else {
+        else if (mSiteId.equals("MLM")){
+            mTermsAndConditionsWebView.loadUrl("https://www.mercadopago.com.mx/ayuda/terminos-y-condiciones_715");
+        }
+        else {
             finish();
         }
     }
 
     private void showBankDealsTermsAndConditions() {
-        MPTextView termsAndConditions = (MPTextView) findViewById(R.id.mpsdkTermsAndConditions);
-        termsAndConditions.setText(getIntent().getStringExtra("termsAndConditions"));
+        mBankDealsLegalsTextView.setText(mBankDealsTermsAndConditions);
     }
 }


### PR DESCRIPTION
Cobertura de líneas: 99%
Cobertura de branches:  92%

Se cambió la key con la cual se envían los terminos y condiciones de las promociones  de "termsAndConditions" por "bankDealLegals", porque esta pantalla se encarga también de los términos y condiciones de MercadoPago y quedaba confuso.