### PR TITLE
Reduje el tiempo del hold de animación

### DIFF
--- a/sdk/src/main/res/anim/mpsdk_hold.xml
+++ b/sdk/src/main/res/anim/mpsdk_hold.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android">
-    <translate android:fromYDelta="0%p" android:toYDelta="0%p" android:duration="2000"/>
+    <translate android:fromYDelta="0%p" android:toYDelta="0%p" android:duration="200"/>
 </set>


### PR DESCRIPTION
Animación que afectaba al seleccionar un banco, ahora es más rápida porque antes parecía "colgarse".

![bancos1](https://cloud.githubusercontent.com/assets/5674142/17214277/837f8a00-54ae-11e6-8606-10bc809f7c67.gif)
