### PR TITLE
Fix bug código de seguridad

### DIFF
--- a/sdk/src/androidTest/java/com/mercadopago/GuessingCardActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/GuessingCardActivityTest.java
@@ -1617,6 +1617,51 @@ public class GuessingCardActivityTest {
         onView(withId(R.id.mpsdkCardNumberTextView)).check(matches(withText(containsString(card.getNumberWithMask()))));
     }
 
+    @Test
+    public void ignoreOnSecurityCodeNotRequiredThenTryOneWithRequired() {
+        addPaymentMethodsCall();
+        addIdentificationTypesCall();
+        addIdentificationTypesCall();
+
+        mTestRule.launchActivity(validStartIntent);
+        DummyCard card = CardTestUtils.getPaymentMethodOnWithoutRequiredSecurityCode();
+
+        onView(withId(R.id.mpsdkCardNumber)).perform(typeText(card.getCardNumber()));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        onView(withId(R.id.mpsdkCardholderName)).perform(typeText(StaticMock.DUMMY_CARDHOLDER_NAME));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        onView(withId(R.id.mpsdkCardExpiryDate)).perform(typeText(StaticMock.DUMMY_EXPIRATION_DATE));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        identificationNumberIsCurrentEditText();
+        onView(withId(R.id.mpsdkCardIdentificationNumber)).perform(typeText(StaticMock.DUMMY_IDENTIFICATION_NUMBER));
+
+        onView(withId(R.id.mpsdkBackButton)).perform(click());
+        onView(withId(R.id.mpsdkCardExpiryDate)).check(matches(isDisplayed()));
+        onView(withId(R.id.mpsdkCardExpiryDate)).check(matches(hasFocus()));
+
+        onView(withId(R.id.mpsdkBackButton)).perform(click());
+        cardholderNameIsCurrentEditText();
+
+        onView(withId(R.id.mpsdkBackButton)).perform(click());
+        cardNumberIsCurrentEditText();
+
+        onView(withId(R.id.mpsdkCardNumber)).perform(clearText());
+
+        card = CardTestUtils.getPaymentMethodOnWithBackSecurityCode();
+        onView(withId(R.id.mpsdkCardNumber)).perform(typeText(card.getCardNumber()));
+
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        cardholderNameIsCurrentEditText();
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        expiryDateIsCurrentEditText();
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        securityCodeIsCurrentEditText();
+        onView(withId(R.id.mpsdkCardSecurityCode)).perform(typeText(card.getSecurityCode()));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        identificationNumberIsCurrentEditText();
+    }
+
+
     private void addIdentificationTypesCall() {
         String identificationTypes = StaticMock.getIdentificationTypeList();
         mFakeAPI.addResponseToQueue(identificationTypes, 200, "");

--- a/sdk/src/main/java/com/mercadopago/CardVaultActivity.java
+++ b/sdk/src/main/java/com/mercadopago/CardVaultActivity.java
@@ -104,6 +104,9 @@ public class CardVaultActivity extends ShowCardActivity {
         if (mPublicKey == null) {
             throw new IllegalStateException();
         }
+        if (mInstallmentsEnabled && (mSite == null || mAmount == null)) {
+            throw new IllegalStateException();
+        }
     }
 
     protected void initializeToolbar() {

--- a/sdk/src/main/java/com/mercadopago/GuessingCardActivity.java
+++ b/sdk/src/main/java/com/mercadopago/GuessingCardActivity.java
@@ -427,20 +427,20 @@ public class GuessingCardActivity extends FrontCardActivity {
             case CARD_NUMBER_INPUT:
                 if (validateCardNumber(true)) {
                     mCardNumberInput.setVisibility(View.GONE);
-                    mCardHolderNameEditText.requestFocus();
                     mCardExpiryDateInput.setVisibility(View.VISIBLE);
+                    mCardHolderNameEditText.requestFocus();
                     return true;
                 }
                 return false;
             case CARDHOLDER_NAME_INPUT:
                 if (validateCardName(true)) {
                     mCardholderNameInput.setVisibility(View.GONE);
-                    mCardExpiryDateEditText.requestFocus();
                     if (isSecurityCodeRequired()) {
                         mSecurityCodeEditView.setVisibility(View.VISIBLE);
                     } else if (mIdentificationNumberRequired) {
                         mIdentificationTypeContainer.setVisibility(View.VISIBLE);
                     }
+                    mCardExpiryDateEditText.requestFocus();
                     return true;
                 }
                 return false;
@@ -1130,7 +1130,9 @@ public class GuessingCardActivity extends FrontCardActivity {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
                 mFrontFragment.setFontColor();
-                if (hasFocus) {
+                if (hasFocus && (mCurrentEditingEditText.equals(CARD_EXPIRYDATE_INPUT) ||
+                    mCurrentEditingEditText.equals(CARD_IDENTIFICATION_INPUT) ||
+                    mCurrentEditingEditText.equals(CARD_SECURITYCODE_INPUT))) {
                     MPTracker.getInstance().trackScreen("CARD_SECURITY_CODE", "2", mPublicKey, "MLA", "1.0", getActivity());
 
                     enableBackInputButton();


### PR DESCRIPTION
- Había un bug permitía hacer foco en el código de seguridad en un momento que no era adecuado. Pasaba cuando ingresabas un número de tarjeta que no tiene código de seguridad requerido, avanzabas hasta el número de documento, luego volvías a cambiar el número de tarjeta por uno con código de seguridad requerido y luego avanzabas hacia el código de seguridad.
- Agregué el test que valida este caso de uso
- Agregué validación de CardVault que faltaba para los installments activados