### PR TITLE
Máscara de identification number para CPF y CNPJ

### DIFF
--- a/sdk/src/androidTest/assets/mocks/identification_type_cnpj.json
+++ b/sdk/src/androidTest/assets/mocks/identification_type_cnpj.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "CNPJ",
+    "name": "CNPJ",
+    "type": "number",
+    "min_length": 14,
+    "max_length": 14
+  }
+]

--- a/sdk/src/androidTest/assets/mocks/identification_type_cpf.json
+++ b/sdk/src/androidTest/assets/mocks/identification_type_cpf.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "CPF",
+    "name": "CPF",
+    "type": "number",
+    "min_length": 11,
+    "max_length": 11
+  }
+]

--- a/sdk/src/androidTest/java/com/mercadopago/GuessingCardActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/GuessingCardActivityTest.java
@@ -15,6 +15,7 @@ import android.widget.ImageView;
 import com.google.gson.reflect.TypeToken;
 import com.mercadopago.model.DecorationPreference;
 import com.mercadopago.model.DummyCard;
+import com.mercadopago.model.DummyIdentificationType;
 import com.mercadopago.model.IdentificationType;
 import com.mercadopago.model.Issuer;
 import com.mercadopago.model.PaymentMethod;
@@ -26,6 +27,7 @@ import com.mercadopago.test.StaticMock;
 import com.mercadopago.util.JsonUtil;
 import com.mercadopago.utils.ActivityResultUtil;
 import com.mercadopago.utils.CardTestUtils;
+import com.mercadopago.utils.IdentificationTestUtils;
 import com.mercadopago.utils.ViewUtils;
 import com.mercadopago.views.MPTextView;
 
@@ -1615,6 +1617,80 @@ public class GuessingCardActivityTest {
         onView(withId(R.id.mpsdkCardNumber)).perform(typeText(card.getCardNumber()));
         onView(withId(R.id.mpsdkCardNumber)).check(matches(withText(card.getNumberWithMask())));
         onView(withId(R.id.mpsdkCardNumberTextView)).check(matches(withText(containsString(card.getNumberWithMask()))));
+    }
+
+    @Test
+    public void validateDniMask() {
+        addPaymentMethodsCall();
+        addIdentificationTypesCall();
+        mTestRule.launchActivity(validStartIntent);
+
+        DummyCard card = CardTestUtils.getDummyCard("master");
+        DummyIdentificationType identificationType = IdentificationTestUtils.getDummyIdentificationType("DNI");
+
+        onView(withId(R.id.mpsdkCardNumber)).perform(typeText(card.getCardNumber()));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        onView(withId(R.id.mpsdkCardholderName)).perform(typeText(StaticMock.DUMMY_CARDHOLDER_NAME));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        onView(withId(R.id.mpsdkCardExpiryDate)).perform(typeText(StaticMock.DUMMY_EXPIRATION_DATE));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        onView(withId(R.id.mpsdkCardSecurityCode)).perform(typeText(card.getSecurityCode()));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+
+        validateMask(identificationType);
+    }
+
+    @Test
+    public void validateCPFMask() {
+        addPaymentMethodsCall();
+
+        String identificationTypes = StaticMock.getIdentificationTypeCPF();
+        mFakeAPI.addResponseToQueue(identificationTypes, 200, "");
+
+        mTestRule.launchActivity(validStartIntent);
+
+        DummyCard card = CardTestUtils.getDummyCard("master");
+        DummyIdentificationType identificationType = IdentificationTestUtils.getDummyIdentificationType("CPF");
+
+        onView(withId(R.id.mpsdkCardNumber)).perform(typeText(card.getCardNumber()));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        onView(withId(R.id.mpsdkCardholderName)).perform(typeText(StaticMock.DUMMY_CARDHOLDER_NAME));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        onView(withId(R.id.mpsdkCardExpiryDate)).perform(typeText(StaticMock.DUMMY_EXPIRATION_DATE));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        onView(withId(R.id.mpsdkCardSecurityCode)).perform(typeText(card.getSecurityCode()));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+
+        validateMask(identificationType);
+    }
+
+    @Test
+    public void validateCNPJMask() {
+        addPaymentMethodsCall();
+
+        String identificationTypes = StaticMock.getIdentificationTypeCNPJ();
+        mFakeAPI.addResponseToQueue(identificationTypes, 200, "");
+
+        mTestRule.launchActivity(validStartIntent);
+
+        DummyCard card = CardTestUtils.getDummyCard("master");
+        DummyIdentificationType identificationType = IdentificationTestUtils.getDummyIdentificationType("CNPJ");
+
+        onView(withId(R.id.mpsdkCardNumber)).perform(typeText(card.getCardNumber()));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        onView(withId(R.id.mpsdkCardholderName)).perform(typeText(StaticMock.DUMMY_CARDHOLDER_NAME));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        onView(withId(R.id.mpsdkCardExpiryDate)).perform(typeText(StaticMock.DUMMY_EXPIRATION_DATE));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+        onView(withId(R.id.mpsdkCardSecurityCode)).perform(typeText(card.getSecurityCode()));
+        onView(withId(R.id.mpsdkNextButton)).perform(click());
+
+        validateMask(identificationType);
+    }
+
+    public void validateMask(DummyIdentificationType identificationType) {
+        onView(withId(R.id.mpsdkCardIdentificationNumber)).perform(typeText(identificationType.getIdentificationNumber()));
+        onView(withId(R.id.mpsdkIdNumberView)).check(matches(withText(identificationType.getGetIdentificationNumberWithMask())));
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/mercadopago/model/DummyIdentificationType.java
+++ b/sdk/src/androidTest/java/com/mercadopago/model/DummyIdentificationType.java
@@ -1,0 +1,41 @@
+package com.mercadopago.model;
+
+/**
+ * Created by vaserber on 8/3/16.
+ */
+public class DummyIdentificationType {
+
+    private String id;
+    private String identificationNumber;
+    private String getIdentificationNumberWithMask;
+
+    public DummyIdentificationType(String id, String identificationNumber, String getIdentificationNumberWithMask) {
+        this.id = id;
+        this.identificationNumber = identificationNumber;
+        this.getIdentificationNumberWithMask = getIdentificationNumberWithMask;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getIdentificationNumber() {
+        return identificationNumber;
+    }
+
+    public String getGetIdentificationNumberWithMask() {
+        return getIdentificationNumberWithMask;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setIdentificationNumber(String identificationNumber) {
+        this.identificationNumber = identificationNumber;
+    }
+
+    public void setGetIdentificationNumberWithMask(String getIdentificationNumberWithMask) {
+        this.getIdentificationNumberWithMask = getIdentificationNumberWithMask;
+    }
+}

--- a/sdk/src/androidTest/java/com/mercadopago/test/StaticMock.java
+++ b/sdk/src/androidTest/java/com/mercadopago/test/StaticMock.java
@@ -128,6 +128,28 @@ public class StaticMock {
 
     }
 
+    public static String getIdentificationTypeCPF() {
+
+        try {
+            return getFile(InstrumentationRegistry.getContext(), "mocks/identification_type_cpf.json");
+
+        } catch (Exception ex) {
+            return null;
+        }
+
+    }
+
+    public static String getIdentificationTypeCNPJ() {
+
+        try {
+            return getFile(InstrumentationRegistry.getContext(), "mocks/identification_type_cnpj.json");
+
+        } catch (Exception ex) {
+            return null;
+        }
+
+    }
+
     public static List<PayerCost> getPayerCosts(Context context) {
 
         Installment installment = JsonUtil.getInstance().fromJson(getFile(context, "mocks/installment.json"), Installment.class);

--- a/sdk/src/androidTest/java/com/mercadopago/utils/IdentificationTestUtils.java
+++ b/sdk/src/androidTest/java/com/mercadopago/utils/IdentificationTestUtils.java
@@ -1,0 +1,22 @@
+package com.mercadopago.utils;
+
+import com.mercadopago.model.DummyIdentificationType;
+
+/**
+ * Created by vaserber on 8/3/16.
+ */
+public class IdentificationTestUtils {
+
+    public static DummyIdentificationType getDummyIdentificationType(String id) {
+        switch (id) {
+            case "DNI":
+                return new DummyIdentificationType("DNI", "12345678", "12.345.678");
+            case "CPF":
+                return new DummyIdentificationType("CPF", "12312312344", "123.123.123-44");
+            case "CNPJ":
+                return new DummyIdentificationType("CNPJ", "57215433000181", "57.215.433/0001-81");
+        }
+        return null;
+    }
+
+}

--- a/sdk/src/main/java/com/mercadopago/CardInterface.java
+++ b/sdk/src/main/java/com/mercadopago/CardInterface.java
@@ -1,5 +1,6 @@
 package com.mercadopago;
 
+import com.mercadopago.model.IdentificationType;
 import com.mercadopago.model.PaymentMethod;
 
 public interface CardInterface {
@@ -43,10 +44,6 @@ public interface CardInterface {
 
     void saveCardNumber(String cardNumber);
 
-    String buildNumberWithMask(int cardLength, String s);
-
-    String buildIdentificationNumberWithMask(CharSequence s);
-
     String getCardHolderName();
 
     String getExpiryMonth();
@@ -54,6 +51,8 @@ public interface CardInterface {
     String getExpiryYear();
 
     String getCardIdentificationNumber();
+
+    IdentificationType getCardIdentificationType();
 
     void saveCardExpiryYear(String year);
 

--- a/sdk/src/main/java/com/mercadopago/CardVaultActivity.java
+++ b/sdk/src/main/java/com/mercadopago/CardVaultActivity.java
@@ -11,6 +11,7 @@ import com.mercadopago.callbacks.FailureRecovery;
 import com.mercadopago.constants.PaymentTypes;
 import com.mercadopago.core.MercadoPago;
 import com.mercadopago.model.ApiException;
+import com.mercadopago.model.IdentificationType;
 import com.mercadopago.model.Installment;
 import com.mercadopago.model.Issuer;
 import com.mercadopago.model.PayerCost;
@@ -291,5 +292,10 @@ public class CardVaultActivity extends ShowCardActivity {
     @Override
     public void initializeCardByToken() {
 
+    }
+
+    @Override
+    public IdentificationType getCardIdentificationType() {
+        return null;
     }
 }

--- a/sdk/src/main/java/com/mercadopago/FrontCardActivity.java
+++ b/sdk/src/main/java/com/mercadopago/FrontCardActivity.java
@@ -3,8 +3,6 @@ package com.mercadopago;
 
 import com.mercadopago.model.PaymentMethod;
 
-import java.util.Locale;
-
 public abstract class FrontCardActivity extends MercadoPagoActivity implements CardInterface {
 
     protected String mCardNumber;
@@ -95,77 +93,6 @@ public abstract class FrontCardActivity extends MercadoPagoActivity implements C
         }
         String colorName = "mpsdk_font_" + paymentMethod.getId().toLowerCase();
         return getResources().getIdentifier(colorName, "color", getPackageName());
-    }
-
-    @Override
-    public String buildNumberWithMask(int cardLength, String s) {
-        String result = "";
-        if (cardLength == CARD_NUMBER_AMEX_LENGTH) {
-            StringBuffer sb = new StringBuffer();
-            for (int i = 0; i < 4 ; i++) {
-                char c = getCharOfCard(s, i);
-                sb.append(c);
-            }
-            sb.append(" ");
-            for (int i = 4; i < 10; i++) {
-                char c = getCharOfCard(s, i);
-                sb.append(c);
-            }
-            sb.append(" ");
-            for (int i = 10; i < CARD_NUMBER_AMEX_LENGTH; i++) {
-                char c = getCharOfCard(s, i);
-                sb.append(c);
-            }
-            result = sb.toString();
-        } else if (cardLength == CARD_NUMBER_DINERS_LENGTH) {
-            StringBuffer sb = new StringBuffer();
-            for (int i = 0; i < 4 ; i++) {
-                char c = getCharOfCard(s, i);
-                sb.append(c);
-            }
-            sb.append(" ");
-            for (int i = 4; i < 10; i++) {
-                char c = getCharOfCard(s, i);
-                sb.append(c);
-            }
-            sb.append(" ");
-            for (int i = 10; i < CARD_NUMBER_DINERS_LENGTH; i++) {
-                char c = getCharOfCard(s, i);
-                sb.append(c);
-            }
-            result = sb.toString();
-        } else {
-            StringBuffer sb = new StringBuffer();
-            for (int i = 1; i <= cardLength; i++) {
-                sb.append(getCharOfCard(s, i-1));
-                if (i % 4 == 0) {
-                    sb.append(" ");
-                }
-            }
-            result = sb.toString();
-        }
-        return result;
-    }
-
-    private char getCharOfCard(String s, int i) {
-        if (i < s.length()) {
-            return s.charAt(i);
-        } else {
-            return "•".charAt(0);
-        }
-    }
-
-    public String buildIdentificationNumberWithMask(CharSequence s) {
-        if (s.length() == 0) {
-            return s.toString();
-        }
-        try {
-            Long value = Long.valueOf(s.toString());
-            Locale.setDefault(Locale.GERMAN);
-            return String.format("%,d", value);
-        } catch (NumberFormatException e) {
-            return "";
-        }
     }
 
 }

--- a/sdk/src/main/java/com/mercadopago/GuessingCardActivity.java
+++ b/sdk/src/main/java/com/mercadopago/GuessingCardActivity.java
@@ -560,6 +560,11 @@ public class GuessingCardActivity extends FrontCardActivity {
     }
 
     @Override
+    public IdentificationType getCardIdentificationType() {
+        return mSelectedIdentificationType;
+    }
+
+    @Override
     public void initializeCardByToken() {
         if (mToken == null) {
             return;

--- a/sdk/src/main/java/com/mercadopago/InstallmentsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/InstallmentsActivity.java
@@ -16,6 +16,7 @@ import com.mercadopago.callbacks.FailureRecovery;
 import com.mercadopago.core.MercadoPago;
 import com.mercadopago.listeners.RecyclerItemClickListener;
 import com.mercadopago.model.ApiException;
+import com.mercadopago.model.IdentificationType;
 import com.mercadopago.model.Installment;
 import com.mercadopago.model.PayerCost;
 import com.mercadopago.model.PaymentPreference;
@@ -267,5 +268,10 @@ public class InstallmentsActivity extends ShowCardActivity {
     @Override
     public void initializeCardByToken() {
 
+    }
+
+    @Override
+    public IdentificationType getCardIdentificationType() {
+        return null;
     }
 }

--- a/sdk/src/main/java/com/mercadopago/IssuersActivity.java
+++ b/sdk/src/main/java/com/mercadopago/IssuersActivity.java
@@ -15,6 +15,7 @@ import com.mercadopago.callbacks.FailureRecovery;
 import com.mercadopago.core.MercadoPago;
 import com.mercadopago.listeners.RecyclerItemClickListener;
 import com.mercadopago.model.ApiException;
+import com.mercadopago.model.IdentificationType;
 import com.mercadopago.model.Issuer;
 import com.mercadopago.mptracker.MPTracker;
 import com.mercadopago.util.ApiUtil;
@@ -226,5 +227,10 @@ public class IssuersActivity extends ShowCardActivity {
     @Override
     public void initializeCardByToken() {
 
+    }
+
+    @Override
+    public IdentificationType getCardIdentificationType() {
+        return null;
     }
 }

--- a/sdk/src/main/java/com/mercadopago/fragments/CardFrontFragment.java
+++ b/sdk/src/main/java/com/mercadopago/fragments/CardFrontFragment.java
@@ -21,7 +21,7 @@ import com.mercadopago.core.MercadoPago;
 import com.mercadopago.model.DecorationPreference;
 import com.mercadopago.model.PaymentMethod;
 import com.mercadopago.util.MPAnimationUtils;
-import com.mercadopago.util.MPMaskUtil;
+import com.mercadopago.util.MPCardMaskUtil;
 import com.mercadopago.util.ScaleUtil;
 import com.mercadopago.views.MPEditText;
 import com.mercadopago.views.MPTextView;
@@ -341,10 +341,10 @@ public class CardFrontFragment extends android.support.v4.app.Fragment {
         } else if ((s.length() < MercadoPago.BIN_LENGTH)
                 || (s.length() == MercadoPago.BIN_LENGTH && mActivity.getCurrentPaymentMethod() == null)
                 || (mActivity.getCurrentPaymentMethod() == null) ) {
-            number = MPMaskUtil.buildNumberWithMask(CardInterface.CARD_NUMBER_MAX_LENGTH, s.toString());
+            number = MPCardMaskUtil.buildNumberWithMask(CardInterface.CARD_NUMBER_MAX_LENGTH, s.toString());
         } else {
             int length = mActivity.getCardNumberLength();
-            number = MPMaskUtil.buildNumberWithMask(length, s.toString());
+            number = MPCardMaskUtil.buildNumberWithMask(length, s.toString());
         }
         mCardNumberTextView.setText(number);
     }

--- a/sdk/src/main/java/com/mercadopago/fragments/CardFrontFragment.java
+++ b/sdk/src/main/java/com/mercadopago/fragments/CardFrontFragment.java
@@ -21,6 +21,7 @@ import com.mercadopago.core.MercadoPago;
 import com.mercadopago.model.DecorationPreference;
 import com.mercadopago.model.PaymentMethod;
 import com.mercadopago.util.MPAnimationUtils;
+import com.mercadopago.util.MPMaskUtil;
 import com.mercadopago.util.ScaleUtil;
 import com.mercadopago.views.MPEditText;
 import com.mercadopago.views.MPTextView;
@@ -340,10 +341,10 @@ public class CardFrontFragment extends android.support.v4.app.Fragment {
         } else if ((s.length() < MercadoPago.BIN_LENGTH)
                 || (s.length() == MercadoPago.BIN_LENGTH && mActivity.getCurrentPaymentMethod() == null)
                 || (mActivity.getCurrentPaymentMethod() == null) ) {
-            number = mActivity.buildNumberWithMask(CardInterface.CARD_NUMBER_MAX_LENGTH, s.toString());
+            number = MPMaskUtil.buildNumberWithMask(CardInterface.CARD_NUMBER_MAX_LENGTH, s.toString());
         } else {
             int length = mActivity.getCardNumberLength();
-            number = mActivity.buildNumberWithMask(length, s.toString());
+            number = MPMaskUtil.buildNumberWithMask(length, s.toString());
         }
         mCardNumberTextView.setText(number);
     }

--- a/sdk/src/main/java/com/mercadopago/fragments/CardIdentificationFragment.java
+++ b/sdk/src/main/java/com/mercadopago/fragments/CardIdentificationFragment.java
@@ -12,7 +12,7 @@ import com.mercadopago.CardInterface;
 import com.mercadopago.GuessingCardActivity;
 import com.mercadopago.R;
 import com.mercadopago.model.IdentificationType;
-import com.mercadopago.util.MPMaskUtil;
+import com.mercadopago.util.MPCardMaskUtil;
 import com.mercadopago.views.MPEditText;
 import com.mercadopago.views.MPTextView;
 
@@ -86,7 +86,7 @@ public class CardIdentificationFragment extends android.support.v4.app.Fragment 
             mBaseIdNumberView.setVisibility(View.INVISIBLE);
             mCardIdentificationNumberView.setVisibility(View.VISIBLE);
             int color = CardInterface.NORMAL_TEXT_VIEW_COLOR;
-            String number = MPMaskUtil.buildIdentificationNumberWithMask(identificationNumber, identificationType);
+            String number = MPCardMaskUtil.buildIdentificationNumberWithMask(identificationNumber, identificationType);
             setText(mCardIdentificationNumberView, number, color);
         }
     }
@@ -103,7 +103,7 @@ public class CardIdentificationFragment extends android.support.v4.app.Fragment 
                 public void onTextChanged(CharSequence s, int start, int before, int count) {
                     mBaseIdNumberView.setVisibility(View.INVISIBLE);
                     mCardIdentificationNumberView.setVisibility(View.VISIBLE);
-                    String number = MPMaskUtil.buildIdentificationNumberWithMask(s, mActivity.getCardIdentificationType());
+                    String number = MPCardMaskUtil.buildIdentificationNumberWithMask(s, mActivity.getCardIdentificationType());
                     mCardIdentificationNumberView.setText(number);
                 }
 

--- a/sdk/src/main/java/com/mercadopago/fragments/CardIdentificationFragment.java
+++ b/sdk/src/main/java/com/mercadopago/fragments/CardIdentificationFragment.java
@@ -11,6 +11,8 @@ import android.view.ViewGroup;
 import com.mercadopago.CardInterface;
 import com.mercadopago.GuessingCardActivity;
 import com.mercadopago.R;
+import com.mercadopago.model.IdentificationType;
+import com.mercadopago.util.MPMaskUtil;
 import com.mercadopago.views.MPEditText;
 import com.mercadopago.views.MPTextView;
 
@@ -76,6 +78,7 @@ public class CardIdentificationFragment extends android.support.v4.app.Fragment 
 
     public void populateIdentificationNumber() {
         String identificationNumber = mActivity.getCardIdentificationNumber();
+        IdentificationType identificationType = mActivity.getCardIdentificationType();
         if (identificationNumber == null) {
             mCardIdentificationNumberView.setVisibility(View.INVISIBLE);
             mBaseIdNumberView.setVisibility(View.VISIBLE);
@@ -83,7 +86,7 @@ public class CardIdentificationFragment extends android.support.v4.app.Fragment 
             mBaseIdNumberView.setVisibility(View.INVISIBLE);
             mCardIdentificationNumberView.setVisibility(View.VISIBLE);
             int color = CardInterface.NORMAL_TEXT_VIEW_COLOR;
-            String number = mActivity.buildIdentificationNumberWithMask(identificationNumber);
+            String number = MPMaskUtil.buildIdentificationNumberWithMask(identificationNumber, identificationType);
             setText(mCardIdentificationNumberView, number, color);
         }
     }
@@ -100,7 +103,7 @@ public class CardIdentificationFragment extends android.support.v4.app.Fragment 
                 public void onTextChanged(CharSequence s, int start, int before, int count) {
                     mBaseIdNumberView.setVisibility(View.INVISIBLE);
                     mCardIdentificationNumberView.setVisibility(View.VISIBLE);
-                    String number = mActivity.buildIdentificationNumberWithMask(s);
+                    String number = MPMaskUtil.buildIdentificationNumberWithMask(s, mActivity.getCardIdentificationType());
                     mCardIdentificationNumberView.setText(number);
                 }
 

--- a/sdk/src/main/java/com/mercadopago/util/MPCardMaskUtil.java
+++ b/sdk/src/main/java/com/mercadopago/util/MPCardMaskUtil.java
@@ -8,10 +8,14 @@ import java.util.Locale;
 /**
  * Created by vaserber on 8/3/16.
  */
-public class MPMaskUtil {
+public class MPCardMaskUtil {
 
     public static final int CPF_SEPARATOR_AMOUNT = 3;
     public static final int CNPJ_SEPARATOR_AMOUNT = 4;
+
+    protected MPCardMaskUtil() {
+
+    }
 
     public static String buildNumberWithMask(int cardLength, String number) {
         String result = "";
@@ -67,13 +71,12 @@ public class MPMaskUtil {
     public static char getCharOfCard(String number, int i) {
         if (i < number.length()) {
             return number.charAt(i);
-        } else {
-            return "•".charAt(0);
         }
+        return "•".charAt(0);
     }
 
     public static String buildIdentificationNumberWithMask(CharSequence number, IdentificationType identificationType) {
-        if (identificationType != null) {
+        if (identificationType != null && identificationType.getId() != null) {
             String type = identificationType.getId();
             if (type.equals("CPF")) {
                 return buildIdentificationNumberOfTypeCPF(number, identificationType.getMaxLength());

--- a/sdk/src/main/java/com/mercadopago/util/MPMaskUtil.java
+++ b/sdk/src/main/java/com/mercadopago/util/MPMaskUtil.java
@@ -1,0 +1,131 @@
+package com.mercadopago.util;
+
+import com.mercadopago.CardInterface;
+import com.mercadopago.model.IdentificationType;
+
+import java.util.Locale;
+
+/**
+ * Created by vaserber on 8/3/16.
+ */
+public class MPMaskUtil {
+
+    public static final int CPF_SEPARATOR_AMOUNT = 3;
+    public static final int CNPJ_SEPARATOR_AMOUNT = 4;
+
+    public static String buildNumberWithMask(int cardLength, String number) {
+        String result = "";
+        if (cardLength == CardInterface.CARD_NUMBER_AMEX_LENGTH) {
+            StringBuffer sb = new StringBuffer();
+            for (int i = 0; i < 4 ; i++) {
+                char c = getCharOfCard(number, i);
+                sb.append(c);
+            }
+            sb.append(" ");
+            for (int i = 4; i < 10; i++) {
+                char c = getCharOfCard(number, i);
+                sb.append(c);
+            }
+            sb.append(" ");
+            for (int i = 10; i < CardInterface.CARD_NUMBER_AMEX_LENGTH; i++) {
+                char c = getCharOfCard(number, i);
+                sb.append(c);
+            }
+            result = sb.toString();
+        } else if (cardLength == CardInterface.CARD_NUMBER_DINERS_LENGTH) {
+            StringBuffer sb = new StringBuffer();
+            for (int i = 0; i < 4 ; i++) {
+                char c = getCharOfCard(number, i);
+                sb.append(c);
+            }
+            sb.append(" ");
+            for (int i = 4; i < 10; i++) {
+                char c = getCharOfCard(number, i);
+                sb.append(c);
+            }
+            sb.append(" ");
+            for (int i = 10; i < CardInterface.CARD_NUMBER_DINERS_LENGTH; i++) {
+                char c = getCharOfCard(number, i);
+                sb.append(c);
+            }
+            result = sb.toString();
+        } else {
+            StringBuffer sb = new StringBuffer();
+            for (int i = 1; i <= cardLength; i++) {
+                sb.append(getCharOfCard(number, i-1));
+                if (i % 4 == 0) {
+                    sb.append(" ");
+                }
+            }
+            result = sb.toString();
+        }
+        return result;
+    }
+
+
+
+    public static char getCharOfCard(String number, int i) {
+        if (i < number.length()) {
+            return number.charAt(i);
+        } else {
+            return "•".charAt(0);
+        }
+    }
+
+    public static String buildIdentificationNumberWithMask(CharSequence number, IdentificationType identificationType) {
+        if (identificationType != null) {
+            String type = identificationType.getId();
+            if (type.equals("CPF")) {
+                return buildIdentificationNumberOfTypeCPF(number, identificationType.getMaxLength());
+            } else if (type.equals("CNPJ")) {
+                return buildIdentificationNumberOfTypeCNPJ(number, identificationType.getMaxLength());
+            }
+        }
+        return buildIdentificationNumberWithDecimalSeparator(number);
+    }
+
+    public static String buildIdentificationNumberWithDecimalSeparator(CharSequence number) {
+        if (number.length() == 0) {
+            return number.toString();
+        }
+        try {
+            Long value = Long.valueOf(number.toString());
+            Locale.setDefault(Locale.GERMAN);
+            return String.format("%,d", value);
+        } catch (NumberFormatException e) {
+            return "";
+        }
+    }
+
+    public static String buildIdentificationNumberOfTypeCPF(CharSequence number, int maxLength) {
+        String result = "";
+        StringBuffer sb = new StringBuffer();
+        for ( int i = 0; i < (maxLength + CPF_SEPARATOR_AMOUNT) && i < number.length(); i++) {
+            if (i == 3 || i  == 6) {
+                sb.append(".");
+            } else if (i == 9) {
+                sb.append("-");
+            }
+            sb.append(number.charAt(i));
+        }
+        result = sb.toString();
+        return result;
+    }
+
+    public static String buildIdentificationNumberOfTypeCNPJ(CharSequence number, int maxLength) {
+        String result = "";
+        StringBuffer sb = new StringBuffer();
+        for ( int i = 0; i < (maxLength + CNPJ_SEPARATOR_AMOUNT) && i < number.length(); i++) {
+            if (i == 2 || i == 5) {
+                sb.append(".");
+            } else if (i == 8) {
+                sb.append("/");
+            } else if (i == 12) {
+                sb.append("-");
+            }
+            sb.append(number.charAt(i));
+        }
+        result = sb.toString();
+        return result;
+    }
+}


### PR DESCRIPTION
## Máscara de identification number para CPF y CNPJ

- Se agrega la máscara para CPF y CNPJ 
- Se agrega una clase MPMaskUtil donde se agrupa las máscaras de identificación y de los números de tarjeta
- Se agregan tests para validar las máscaras de DNI, CPF y CNPJ

## CNPJ 
![screen shot 2016-08-03 at 4 25 49 pm](https://cloud.githubusercontent.com/assets/5674142/17379567/67d9c9a6-5999-11e6-90be-2723b5d7988e.png)

## CPF
![screen shot 2016-08-03 at 4 27 01 pm](https://cloud.githubusercontent.com/assets/5674142/17379566/67d636d8-5999-11e6-85fa-07ceb5e61644.png)
