### PR TITLE
Agregué chequeo para mostrar promos

### DIFF
--- a/sdk/src/androidTest/java/com/mercadopago/BankDealsActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/BankDealsActivityTest.java
@@ -94,6 +94,22 @@ public class BankDealsActivityTest {
     }
 
     @Test
+    public void ifBankDealsReceivedInIntentShowThemInRecyclerView() {
+        String bankDealsJson = StaticMock.getBankDealsJson();
+        validStartIntent.putExtra("bankDeals", bankDealsJson);
+
+        mTestRule.launchActivity(validStartIntent);
+
+        // Validate view
+        RecyclerView list = (RecyclerView) mTestRule.getActivity().findViewById(R.id.mpsdkBankDealsList);
+        if ((list != null) && (list.getAdapter() != null)) {
+            assertTrue(list.getAdapter().getItemCount() > 0);
+        } else {
+            fail("Bank Deals test failed, no items found");
+        }
+    }
+
+    @Test
     public void onBankDealSelectedStartTermsAndConditionsActivityWithBankDealLegals() {
         List<BankDeal> bankDeals = StaticMock.getBankDeals();
         mFakeAPI.addResponseToQueue(bankDeals, 200, "");

--- a/sdk/src/main/java/com/mercadopago/core/MercadoPago.java
+++ b/sdk/src/main/java/com/mercadopago/core/MercadoPago.java
@@ -274,11 +274,14 @@ public class MercadoPago {
 
     // * Static methods for StartActivityBuilder implementation
 
-    private static void startBankDealsActivity(Activity activity, String publicKey, DecorationPreference decorationPreference) {
+    private static void startBankDealsActivity(Activity activity, String publicKey, List<BankDeal> bankDeals, DecorationPreference decorationPreference) {
 
         Intent bankDealsIntent = new Intent(activity, BankDealsActivity.class);
         bankDealsIntent.putExtra("merchantPublicKey", publicKey);
         bankDealsIntent.putExtra("decorationPreference", JsonUtil.getInstance().toJson(decorationPreference));
+        if (bankDeals != null) {
+            bankDealsIntent.putExtra("bankDeals", JsonUtil.getInstance().toJson(bankDeals));
+        }
         activity.startActivityForResult(bankDealsIntent, BANK_DEALS_REQUEST_CODE);
     }
 
@@ -600,6 +603,7 @@ public class MercadoPago {
         private DecorationPreference mDecorationPreference;
         private Boolean mInstallmentsEnabled;
         private List<String> mSupportedPaymentTypes;
+        private List<BankDeal> mBankDeals;
 
         public StartActivityBuilder() {
 
@@ -642,6 +646,11 @@ public class MercadoPago {
 
             this.mKey = key;
             this.mKeyType = MercadoPago.KEY_TYPE_PUBLIC;
+            return this;
+        }
+
+        public StartActivityBuilder setBankDeals(List<BankDeal> bankDeals) {
+            this.mBankDeals = bankDeals;
             return this;
         }
 
@@ -753,7 +762,7 @@ public class MercadoPago {
             if (this.mKeyType == null) throw new IllegalStateException("key type is null");
 
             if (this.mKeyType.equals(KEY_TYPE_PUBLIC)) {
-                MercadoPago.startBankDealsActivity(this.mActivity, this.mKey, this.mDecorationPreference);
+                MercadoPago.startBankDealsActivity(this.mActivity, this.mKey, this.mBankDeals, this.mDecorationPreference);
             } else {
                 throw new RuntimeException("Unsupported key type for this method");
             }


### PR DESCRIPTION
## Agregué chequeo para mostrar promos

- Se agrega llamada a la API en GuessingCardActivity para saber si hay promociones, y si no las hay no se muestra el texto en "Ver Promociones" en Toolbar.
- Se agrega que se pueda enviar una lista de Bank Deals a la pantalla de Bank Deals para evitar la doble llamada a la API
- Se agregan tests en GuessingCardActivityTest y en BankDealsActivityTest para validar casos de uso con lista de bank deals vacía y no vacía
