### PR TITLE
Fix en "back" desde CardVaultActivity sin cuotas

### DIFF
--- a/sdk/src/main/java/com/mercadopago/CardVaultActivity.java
+++ b/sdk/src/main/java/com/mercadopago/CardVaultActivity.java
@@ -212,8 +212,13 @@ public class CardVaultActivity extends ShowCardActivity {
                 finishWithResult();
             }
 
-        } else if (resultCode == RESULT_CANCELED){
-            MPTracker.getInstance().trackEvent( "GUESSING_CARD", "CANCELED", 2, mPublicKey, mSite.getId(), BuildConfig.VERSION_NAME, this);
+        } else if (resultCode == RESULT_CANCELED ) {
+
+            if(mSite == null) {
+                MPTracker.getInstance().trackEvent("GUESSING_CARD", "CANCELED", 2, mPublicKey, BuildConfig.VERSION_NAME, this);
+            } else {
+                MPTracker.getInstance().trackEvent("GUESSING_CARD", "CANCELED", 2, mPublicKey, mSite.getId(), BuildConfig.VERSION_NAME, this);
+            }
 
             setResult(RESULT_CANCELED, data);
             finish();

--- a/sdk/src/main/java/com/mercadopago/model/ApiException.java
+++ b/sdk/src/main/java/com/mercadopago/model/ApiException.java
@@ -80,7 +80,7 @@ public class ApiException {
         public static final String INVALID_PAYMENT_METHOD_ID = "3029";
         public static final String INVALID_CARD_EXPIRATION_MONTH = "3030";
         public static final String INVALID_CARD_EXPIRATION_YEAR = "4000";
-        public static final String INVALID_PAYER_EMAIL = "4051";
+        public static final String INVALID_PAYER_EMAIL = "4050";
     }
 }
 

--- a/sdk/src/main/java/com/mercadopago/uicontrollers/paymentmethodsearch/PaymentMethodSearchSmallRow.java
+++ b/sdk/src/main/java/com/mercadopago/uicontrollers/paymentmethodsearch/PaymentMethodSearchSmallRow.java
@@ -1,6 +1,7 @@
 package com.mercadopago.uicontrollers.paymentmethodsearch;
 
 import android.content.Context;
+import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -56,12 +57,12 @@ public class PaymentMethodSearchSmallRow extends PaymentMethodSearchRow {
         return mView;
     }
 
-    private void setTintColor(Context mContext, ImageView mIcon) {
+    private void setTintColor(Context context, ImageView mIcon) {
         if(mDecorationPreference != null && mDecorationPreference.hasColors()) {
             mIcon.setColorFilter(mDecorationPreference.getBaseColor());
         }
         else {
-            mIcon.setColorFilter(mContext.getResources().getColor(R.color.mpsdk_icon_image_color));
+            mIcon.setColorFilter(ContextCompat.getColor(context, R.color.mpsdk_icon_image_color));
         }
     }
 


### PR DESCRIPTION
Cuando no hay cuotas, no es requerido para el usuario envíar el Site. El trackeo del "back" hace site.getId(), lo que daba como resultado un NullPointerException cuando no estaba seteado.