### PR TITLE
Se agregaron build variants para consumir API beta en desarrollo

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -11,7 +11,7 @@ android {
         versionCode 1
         versionName "1.0"
     }
-    
+
     lintOptions {
         abortOnError false
     }
@@ -20,11 +20,18 @@ android {
         // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
         preDexLibraries = preDexEnabled && !travisBuild
     }
+    productFlavors {
+        dev {
+        }
+        prod {
+        }
+    }
 
 }
 
 dependencies {
-    compile project(':sdk')
+    devCompile project(path: ':sdk', configuration:'devDebug')
+    prodCompile project(path: ':sdk', configuration:'prodDebug')
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.3.0'
     compile 'com.android.support:design:23.3.0'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -8,6 +8,7 @@ group = "com.mercadopago"
 archivesBaseName = "android-sdk"
 
 android {
+    publishNonDefault true
     compileSdkVersion 23
     buildToolsVersion "23.0.2"
     defaultConfig {
@@ -37,7 +38,6 @@ android {
         debug {
             versionNameSuffix " Debug"
             debuggable true
-            testCoverageEnabled true
         }
     }
     dexOptions {
@@ -46,6 +46,15 @@ android {
     }
     lintOptions {
         abortOnError false
+    }
+
+    productFlavors {
+        dev {
+            buildConfigField "String", "API_VERSION", "\"beta\""
+        }
+        prod {
+            buildConfigField "String", "API_VERSION", "\"v1\""
+        }
     }
 }
 dependencies {

--- a/sdk/src/main/java/com/mercadopago/services/PaymentService.java
+++ b/sdk/src/main/java/com/mercadopago/services/PaymentService.java
@@ -1,5 +1,6 @@
 package com.mercadopago.services;
 
+import com.mercadopago.BuildConfig;
 import com.mercadopago.adapters.MPCall;
 import com.mercadopago.model.CheckoutPreference;
 import com.mercadopago.model.Installment;
@@ -34,12 +35,12 @@ public interface PaymentService {
     @GET("/v1/payment_methods/card_issuers")
     MPCall<List<Issuer>> getIssuers(@Query("public_key") String publicKey, @Query("payment_method_id") String paymentMethodId, @Query("bin") String bin);
 
-    @POST("/v1/checkout/payments")
+    @POST("/" + BuildConfig.API_VERSION + "/checkout/payments")
     MPCall<Payment> createPayment(@Header("X-Idempotency-Key") String transactionId, @Body PaymentIntent body);
 
-    @GET("/v1/checkout/payments/{payment_id}/results")
+    @GET("/" + BuildConfig.API_VERSION + "/checkout/payments/{payment_id}/results")
     MPCall<PaymentResult> getPaymentResult(@Path(value = "payment_id", encoded = true) Long paymentId, @Query("public_key") String mKey, @Query("payment_type") String paymentTypeId);
 
-    @GET("/v1/checkout/preferences/{preference_id}")
+    @GET("/" + BuildConfig.API_VERSION + "/checkout/preferences/{preference_id}")
     MPCall<CheckoutPreference> getPreference(@Path(value = "preference_id", encoded = true) String checkoutPreferenceId, @Query("public_key") String publicKey);
 }


### PR DESCRIPTION
Se cambian desde la sección "Build variants":

![captura de pantalla 2016-08-10 a las 12 12 40 p m](https://cloud.githubusercontent.com/assets/11367894/17559255/fb11ff04-5ef3-11e6-9fce-43bc164360c5.png)

Para ir a beta, seleccionar un build variant con prefijo "dev": devDebug durante el desarrollo.
Para ir a v1, con prefijo "prod": prodDebug durante el desarrollo.
