### PR TITLE
Refactor Instrucciones

### DIFF
--- a/sdk/src/androidTest/java/com/mercadopago/InstructionsActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/InstructionsActivityTest.java
@@ -56,7 +56,7 @@ public class InstructionsActivityTest {
 
     private Payment mPayment;
     private String mMerchantPublicKey;
-    private PaymentMethod mPaymentMethod;
+    private String mPaymentTypeId;
     private FakeAPI mFakeAPI;
 
 
@@ -64,11 +64,11 @@ public class InstructionsActivityTest {
     public void createValidStartIntent() {
         mPayment = StaticMock.getPayment();
         mMerchantPublicKey = "1234";
-        mPaymentMethod = getOfflinePaymentMethod();
+        mPaymentTypeId = "ticket";
 
         validStartIntent = new Intent();
         validStartIntent.putExtra("merchantPublicKey", mMerchantPublicKey);
-        validStartIntent.putExtra("paymentMethod", JsonUtil.getInstance().toJson(mPaymentMethod));
+        validStartIntent.putExtra("paymentTypeId", mPaymentTypeId);
         validStartIntent.putExtra("payment", JsonUtil.getInstance().toJson(mPayment));
     }
 
@@ -100,7 +100,7 @@ public class InstructionsActivityTest {
         InstructionsActivity activity = mTestRule.launchActivity(validStartIntent);
         assertEquals(activity.mMerchantPublicKey, mMerchantPublicKey);
         assertEquals(activity.mPayment.getId(), mPayment.getId());
-        assertEquals(activity.mPaymentMethod.getId(), mPaymentMethod.getId());
+        assertEquals(activity.mPaymentTypeId, "ticket");
     }
 
     //Instructions data
@@ -340,12 +340,12 @@ public class InstructionsActivityTest {
     }
 
     @Test
-    public void ifPaymentMethodNotSetStartErrorActivity() {
+    public void ifPaymentTypeIdNotSetStartErrorActivity() {
         PaymentResult instructionWithoutActions = StaticMock.getInstructionWithoutActions();
         mFakeAPI.addResponseToQueue(instructionWithoutActions, 200, "");
-        Intent startWithoutPaymentMethod = new Intent(validStartIntent);
-        startWithoutPaymentMethod.removeExtra("paymentMethod");
-        mTestRule.launchActivity(startWithoutPaymentMethod);
+        Intent startWithoutPaymentTypeId = new Intent(validStartIntent);
+        startWithoutPaymentTypeId.removeExtra("paymentTypeId");
+        mTestRule.launchActivity(startWithoutPaymentTypeId);
         intended(hasComponent(ErrorActivity.class.getName()));
     }
 
@@ -360,13 +360,13 @@ public class InstructionsActivityTest {
     }
 
     @Test
-    public void ifCardPaymentMethodSetStartErrorActivity() {
+    public void ifCardPaymentTypeIdSetStartErrorActivity() {
         PaymentResult instructionWithoutActions = StaticMock.getInstructionWithoutActions();
         mFakeAPI.addResponseToQueue(instructionWithoutActions, 200, "");
-        mPaymentMethod.setPaymentTypeId("credit_card");
+        mPaymentTypeId = "credit_card";
 
         Intent startWithCardPaymentMethod = new Intent(validStartIntent);
-        startWithCardPaymentMethod.putExtra("paymentMethod", JsonUtil.getInstance().toJson(mPaymentMethod));
+        startWithCardPaymentMethod.putExtra("paymentTypeId", mPaymentTypeId);
 
         mTestRule.launchActivity(startWithCardPaymentMethod);
         intended(hasComponent(ErrorActivity.class.getName()));
@@ -456,21 +456,12 @@ public class InstructionsActivityTest {
 
     @Test
     public void ifManyInstructionsFromServiceAndNoneMatchesTypeShowErrorScreen() {
+        String paymentTypeId = "crazy_type";
         PaymentResult manyInstructions = StaticMock.getInstructions();
         mFakeAPI.addResponseToQueue(manyInstructions, 200, "");
-        PaymentMethod paymentMethod = getOfflinePaymentMethod();
-        paymentMethod.setPaymentTypeId("crazy_type");
-        validStartIntent.putExtra("paymentMethod", JsonUtil.getInstance().toJson(paymentMethod));
+        validStartIntent.putExtra("paymentTypeId", paymentTypeId);
         mTestRule.launchActivity(validStartIntent);
 
         intended(hasComponent(ErrorActivity.class.getName()));
-    }
-
-    private PaymentMethod getOfflinePaymentMethod() {
-        PaymentMethod paymentMethod = new PaymentMethod();
-        paymentMethod.setId("oxxo");
-        paymentMethod.setName("Oxxo");
-        paymentMethod.setPaymentTypeId("ticket");
-        return paymentMethod;
     }
 }

--- a/sdk/src/main/java/com/mercadopago/PaymentResultActivity.java
+++ b/sdk/src/main/java/com/mercadopago/PaymentResultActivity.java
@@ -18,7 +18,6 @@ public class PaymentResultActivity extends Activity {
     //Params
     protected Payment mPayment;
     protected PaymentMethod mPaymentMethod;
-
     private String mMerchantPublicKey;
 
     @Override
@@ -89,7 +88,7 @@ public class PaymentResultActivity extends Activity {
                 .setPublicKey(mMerchantPublicKey)
                 .setActivity(this)
                 .setPayment(mPayment)
-                .setPaymentMethod(mPaymentMethod)
+                .setPaymentTypeId(mPaymentMethod.getPaymentTypeId())
                 .startInstructionsActivity();
     }
 

--- a/sdk/src/main/java/com/mercadopago/core/MercadoPago.java
+++ b/sdk/src/main/java/com/mercadopago/core/MercadoPago.java
@@ -343,12 +343,12 @@ public class MercadoPago {
         activity.startActivityForResult(rejectionIntent, REJECTION_REQUEST_CODE);
     }
 
-    private static void startInstructionsActivity(Activity activity, String merchantPublicKey, Payment payment, PaymentMethod paymentMethod) {
+    private static void startInstructionsActivity(Activity activity, String merchantPublicKey, Payment payment, String paymentTypeId) {
 
         Intent instructionIntent = new Intent(activity, InstructionsActivity.class);
         instructionIntent.putExtra("merchantPublicKey", merchantPublicKey);
+        instructionIntent.putExtra("paymentTypeId", paymentTypeId);
         instructionIntent.putExtra("payment", JsonUtil.getInstance().toJson(payment));
-        instructionIntent.putExtra("paymentMethod", JsonUtil.getInstance().toJson(paymentMethod));
 
         activity.startActivityForResult(instructionIntent, INSTRUCTIONS_REQUEST_CODE);
     }
@@ -589,6 +589,7 @@ public class MercadoPago {
         private String mMerchantAccessToken;
         private String mMerchantBaseUrl;
         private String mMerchantGetCustomerUri;
+        private String mPaymentTypeId;
         private List<PayerCost> mPayerCosts;
         private List<Issuer> mIssuers;
         private Payment mPayment;
@@ -697,6 +698,13 @@ public class MercadoPago {
             this.mPaymentMethod = paymentMethod;
             return this;
         }
+
+        public StartActivityBuilder setPaymentTypeId(String paymentTypeId) {
+
+            this.mPaymentTypeId = paymentTypeId;
+            return this;
+        }
+
 
         public StartActivityBuilder setSupportedPaymentMethods(List<PaymentMethod> paymentMethodList) {
 
@@ -868,13 +876,12 @@ public class MercadoPago {
 
             if (this.mActivity == null) throw new IllegalStateException("activity is null");
             if (this.mPayment == null) throw new IllegalStateException("payment is null");
-            if (this.mPaymentMethod == null)
-                throw new IllegalStateException("payment method is null");
+            if (this.mPaymentTypeId == null) throw new IllegalStateException("payment type id is null");
             if (this.mKey == null) throw new IllegalStateException("key is null");
             if (this.mKeyType == null) throw new IllegalStateException("key type is null");
 
             if (this.mKeyType.equals(KEY_TYPE_PUBLIC)) {
-                MercadoPago.startInstructionsActivity(this.mActivity, this.mKey, this.mPayment, this.mPaymentMethod);
+                MercadoPago.startInstructionsActivity(this.mActivity, this.mKey, this.mPayment, this.mPaymentTypeId);
             } else {
                 throw new RuntimeException("Unsupported key type for this method");
             }


### PR DESCRIPTION
Se modificó la InstructionActivity. Antes se iniciaba con un payment, una publicKey y un paymentMethod. Ahora se inicia con un payment, una publicKey y un paymentTypeId. 
Solo utilizábamos el paymentTypeId del paymentMethod y además de esta forma estamos alineados con el SDK de IOS.