### PR TITLE
Fix crash when restoring app 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
     }
 }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '22.0.1'
+    buildToolsVersion '24.0.2'
 
     defaultConfig {
         applicationId "com.mercadopago.example"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ archivesBaseName = "android-sdk"
 android {
     publishNonDefault true
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion '24.0.2'
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 23
@@ -38,6 +38,7 @@ android {
         debug {
             versionNameSuffix " Debug"
             debuggable true
+//            testCoverageEnabled true
         }
     }
     dexOptions {
@@ -56,6 +57,11 @@ android {
             buildConfigField "String", "API_VERSION", "\"v1\""
         }
     }
+//    project.gradle.taskGraph.whenReady {
+//        connectedDevDebugAndroidTest {
+//            ignoreFailures = true
+//        }
+//    }
 }
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')

--- a/sdk/src/androidTest/java/com/mercadopago/IssuersActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/IssuersActivityTest.java
@@ -252,7 +252,16 @@ public class IssuersActivityTest {
         mTestRule.launchActivity(validStartIntent);
 
         RecyclerView referencesLayout = (RecyclerView) mTestRule.getActivity().findViewById(R.id.mpsdkActivityIssuersView);
-        assertEquals(referencesLayout.getChildCount(), issuerList.size());
+        sleep();
+        assertEquals(referencesLayout.getAdapter().getItemCount(), issuerList.size());
+    }
+
+    private void sleep() {
+        try {
+            Thread.sleep(9000);
+        } catch (InterruptedException e) {
+
+        }
     }
 
     @Test
@@ -313,7 +322,7 @@ public class IssuersActivityTest {
         onView(withId(R.id.mpsdkErrorRetry)).perform(click());
 
         RecyclerView referencesLayout = (RecyclerView) mTestRule.getActivity().findViewById(R.id.mpsdkActivityIssuersView);
-        assertEquals(referencesLayout.getChildCount(), issuerList.size());
+        assertEquals(referencesLayout.getAdapter().getItemCount(), issuerList.size());
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/mercadopago/test/StaticMock.java
+++ b/sdk/src/androidTest/java/com/mercadopago/test/StaticMock.java
@@ -61,9 +61,11 @@ public class StaticMock {
     public final static int DUMMY_EXPIRATION_YEAR_SHORT = 25;
     public final static int DUMMY_EXPIRATION_YEAR_LONG = 2025;
     public final static String DUMMY_IDENTIFICATION_NUMBER = "12345678";
+    public final static String DUMMY_IDENTIFICATION_NUMBER_WITH_MASK = "12.345.678";
     public final static String DUMMY_IDENTIFICATION_TYPE = "DNI";
     public final static String DUMMY_SECURITY_CODE = "123";
     public final static String DUMMY_EXPIRATION_DATE = "1225";
+    public final static String DUMMY_EXPIRATION_DATE_WITH_MASK = "12/25";
     public final static String DUMMY_CI_NUMBER = "123456789";
     public final static String DUMMY_LC_NUMBER = "1234567";
     public final static String DUMMY_LE_NUMBER = "1234567";

--- a/sdk/src/main/java/com/mercadopago/FrontCardActivity.java
+++ b/sdk/src/main/java/com/mercadopago/FrontCardActivity.java
@@ -1,9 +1,17 @@
 package com.mercadopago;
 
 
+import android.os.Bundle;
+
 import com.mercadopago.model.PaymentMethod;
 
 public abstract class FrontCardActivity extends MercadoPagoActivity implements CardInterface {
+
+    public static final String EXPIRY_MONTH = "mExpiryMonth";
+    public static final String EXPIRY_YEAR = "mExpiryYear";
+    public static final String CARD_IMAGE_PREFIX = "ico_card_";
+    public static final String CARD_COLOR_PREFIX = "mpsdk_";
+    public static final String CARD_FONT_PREFIX = "mpsdk_font_";
 
     protected String mCardNumber;
     protected String mCardHolderName;
@@ -13,6 +21,20 @@ public abstract class FrontCardActivity extends MercadoPagoActivity implements C
     protected String mErrorState;
     protected String mSecurityCode = "";
     protected PaymentMethod mCurrentPaymentMethod;
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(EXPIRY_MONTH, mExpiryMonth);
+        outState.putString(EXPIRY_YEAR, mExpiryYear);
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Bundle savedInstanceState) {
+        mExpiryMonth = savedInstanceState.getString(EXPIRY_MONTH);
+        mExpiryYear = savedInstanceState.getString(EXPIRY_YEAR);
+        super.onRestoreInstanceState(savedInstanceState);
+    }
 
     public String getCardNumber() {
         return mCardNumber;
@@ -76,13 +98,13 @@ public abstract class FrontCardActivity extends MercadoPagoActivity implements C
 
     @Override
     public int getCardImage(PaymentMethod paymentMethod) {
-        String imageName = "ico_card_" + paymentMethod.getId().toLowerCase();
+        String imageName = CARD_IMAGE_PREFIX + paymentMethod.getId().toLowerCase();
         return getResources().getIdentifier(imageName, "drawable", getPackageName());
     }
 
     @Override
     public int getCardColor(PaymentMethod paymentMethod) {
-        String colorName = "mpsdk_" + paymentMethod.getId().toLowerCase();
+        String colorName = CARD_COLOR_PREFIX + paymentMethod.getId().toLowerCase();
         return getResources().getIdentifier(colorName, "color", getPackageName());
     }
 
@@ -91,7 +113,7 @@ public abstract class FrontCardActivity extends MercadoPagoActivity implements C
         if (paymentMethod == null) {
             return getResources().getColor(CardInterface.FULL_TEXT_VIEW_COLOR);
         }
-        String colorName = "mpsdk_font_" + paymentMethod.getId().toLowerCase();
+        String colorName = CARD_FONT_PREFIX + paymentMethod.getId().toLowerCase();
         return getResources().getIdentifier(colorName, "color", getPackageName());
     }
 

--- a/sdk/src/main/java/com/mercadopago/fragments/CardFrontFragment.java
+++ b/sdk/src/main/java/com/mercadopago/fragments/CardFrontFragment.java
@@ -181,7 +181,7 @@ public class CardFrontFragment extends android.support.v4.app.Fragment {
                 public void onTextChanged(CharSequence s, int start, int before, int count) {
                     if (start <= 2) {
                         CharSequence month = s;
-                        if (s.length() == 3) {
+                        if (s.length() >= 3) {
                             month = s.subSequence(0, 2);
                         }
                         mCardExpiryMonthTextView.setText(month);

--- a/sdk/src/main/java/com/mercadopago/fragments/CardFrontFragment.java
+++ b/sdk/src/main/java/com/mercadopago/fragments/CardFrontFragment.java
@@ -28,8 +28,10 @@ import com.mercadopago.views.MPTextView;
 
 public class CardFrontFragment extends android.support.v4.app.Fragment {
 
-    int EDITING_TEXT_VIEW_ALPHA = 255;
-    int NORMAL_TEXT_VIEW_ALPHA = 179;
+    private static final int EDITING_TEXT_VIEW_ALPHA = 255;
+    private static final int NORMAL_TEXT_VIEW_ALPHA = 179;
+    private static final int MONTH_LENGTH = 2;
+    private static final int YEAR_START_INDEX = 3;
 
     //Card input views
     private MPTextView mCardNumberTextView;
@@ -57,8 +59,8 @@ public class CardFrontFragment extends android.support.v4.app.Fragment {
 
     private CardInterface mActivity;
 
-    public static String BASE_NUMBER_CARDHOLDER = "•••• •••• •••• ••••";
-    public static String BASE_FRONT_SECURITY_CODE = "••••";
+    public static final String BASE_NUMBER_CARDHOLDER = "•••• •••• •••• ••••";
+    public static final String BASE_FRONT_SECURITY_CODE = "••••";
 
     public CardFrontFragment() {
         this.mAnimate = true;
@@ -179,15 +181,15 @@ public class CardFrontFragment extends android.support.v4.app.Fragment {
 
                 @Override
                 public void onTextChanged(CharSequence s, int start, int before, int count) {
-                    if (start <= 2) {
+                    if (start <= MONTH_LENGTH) {
                         CharSequence month = s;
-                        if (s.length() >= 3) {
-                            month = s.subSequence(0, 2);
+                        if (s.length() >= YEAR_START_INDEX) {
+                            month = s.subSequence(0, MONTH_LENGTH);
                         }
                         mCardExpiryMonthTextView.setText(month);
                         mActivity.saveCardExpiryMonth(month.toString());
                     } else {
-                        CharSequence year = s.subSequence(3, s.length());
+                        CharSequence year = s.subSequence(YEAR_START_INDEX, s.length());
                         mCardExpiryYearTextView.setText(year);
                         mActivity.saveCardExpiryYear(year.toString());
                     }
@@ -195,7 +197,7 @@ public class CardFrontFragment extends android.support.v4.app.Fragment {
 
                 @Override
                 public void afterTextChanged(Editable s) {
-                    if (s.length() == 3) {
+                    if (s.length() == YEAR_START_INDEX) {
                         mCardExpiryYearTextView.setText(getResources().getString(R.string.mpsdk_card_expiry_year_hint));
                         mActivity.saveCardExpiryYear(null);
                     } else if (s.length() == 0) {


### PR DESCRIPTION
# Fix crash when restoring app 

- GuessingCardActivity now stores in bundle all the variables and fragments it uses, so that when the OS destroys the app, and then the user comes back to it, its state is restored and the app doesn't crash.
- Stores FrontFragment, BackFragment, IdentificationFragment, and all the variables it needs.
- This was tested using the emulator, activating the developer option: "Don't keep activities (destroy every activity as soon as the user leaves it)".
- Added tests that recreate the activity.
- [Video](https://drive.google.com/open?id=0B7v04H2J8VPCVEpUd2NWRmlwVzg
)

**Requirements**

## Coverage:

- Coverage of GuessingCardActivity is 90% instructions, 63% branches
- Added tests for methods *onSaveInstanceState* (100% instructions, 67% branches), and for *onRestoreInstanceState* (100% instructions, 50% branches)

- [X] Android Lint check


- [X] Code Style checked

