### PR TITLE
[WAIT for Q4] PaymentType Spinner

### DIFF
--- a/example/src/main/java/com/mercadopago/examples/components/ComponentsExampleActivity.java
+++ b/example/src/main/java/com/mercadopago/examples/components/ComponentsExampleActivity.java
@@ -96,9 +96,9 @@ public class ComponentsExampleActivity extends AppCompatActivity {
 
         new MercadoPago.StartActivityBuilder()
                 .setActivity(this)
-                .setPublicKey(mPublicKey)
+                .setPublicKey("6c0d81bc-99c1-4de8-9976-c8d1d62cd4f2")
                 .setAmount(mAmount)
-                .setSite(Sites.ARGENTINA)
+                .setSite(Sites.MEXICO)
                 .setInstallmentsEnabled(true)
                 .setPaymentPreference(paymentPreference) //Optional
                 .setDecorationPreference(decorationPreference) //Optional

--- a/example/src/main/java/com/mercadopago/examples/components/ComponentsExampleActivity.java
+++ b/example/src/main/java/com/mercadopago/examples/components/ComponentsExampleActivity.java
@@ -78,8 +78,8 @@ public class ComponentsExampleActivity extends AppCompatActivity {
 
         new MercadoPago.StartActivityBuilder()
                 .setActivity(this)
-                .setPublicKey(mPublicKey)
-                .setSite(Sites.ARGENTINA)
+                .setPublicKey("6c0d81bc-99c1-4de8-9976-c8d1d62cd4f2")
+                .setSite(Sites.MEXICO)
                 .setAmount(mAmount)
                 .setPaymentPreference(paymentPreference) //Optional
                 .setDecorationPreference(decorationPreference) //Optional

--- a/sdk/src/androidTest/assets/mocks/payment_method_list_mlm.json
+++ b/sdk/src/androidTest/assets/mocks/payment_method_list_mlm.json
@@ -1,0 +1,235 @@
+[
+  {
+    "id": "visa",
+    "name": "Visa",
+    "payment_type_id": "credit_card",
+    "status": "active",
+    "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/visa.gif",
+    "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/visa.gif",
+    "deferred_capture": "unsupported",
+    "settings": [
+      {
+        "bin": {
+          "pattern": "^4",
+          "exclusion_pattern": null,
+          "installments_pattern": "^4"
+        },
+        "card_number": {
+          "length": 16,
+          "validation": "standard"
+        },
+        "security_code": {
+          "mode": "mandatory",
+          "length": 3,
+          "card_location": "back"
+        }
+      }
+    ],
+    "additional_info_needed": [
+      "cardholder_name",
+      "issuer_id"
+    ],
+    "min_allowed_amount": 10,
+    "max_allowed_amount": 200000,
+    "accreditation_time": 2880
+  },
+  {
+    "id": "master",
+    "name": "Mastercard",
+    "payment_type_id": "credit_card",
+    "status": "active",
+    "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/master.gif",
+    "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/master.gif",
+    "deferred_capture": "unsupported",
+    "settings": [
+      {
+        "bin": {
+          "pattern": "^5",
+          "exclusion_pattern": "^((506221)|(533987)|(545290)|(545325)|(534926)|(544505)|(522312)|(522794)|(523013)|(527374))",
+          "installments_pattern": "^5"
+        },
+        "card_number": {
+          "length": 16,
+          "validation": "standard"
+        },
+        "security_code": {
+          "mode": "mandatory",
+          "length": 3,
+          "card_location": "back"
+        }
+      }
+    ],
+    "additional_info_needed": [
+      "cardholder_name",
+      "issuer_id"
+    ],
+    "min_allowed_amount": 5,
+    "max_allowed_amount": 200000,
+    "accreditation_time": 2880
+  },
+  {
+    "id": "debmaster",
+    "name": "Mastercard Débito",
+    "payment_type_id": "debit_card",
+    "status": "active",
+    "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/debmaster.gif",
+    "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/debmaster.gif",
+    "deferred_capture": "unsupported",
+    "settings": [
+      {
+        "bin": {
+          "pattern": "^5",
+          "exclusion_pattern": "^((539978)|(506221)|(533987)|(545290)|(545325)|(534926)|(544505)|(522312)|(522794)|(523013)|(527374))",
+          "installments_pattern": "^5"
+        },
+        "card_number": {
+          "length": 16,
+          "validation": "standard"
+        },
+        "security_code": {
+          "mode": "mandatory",
+          "length": 3,
+          "card_location": "back"
+        }
+      }
+    ],
+    "additional_info_needed": [
+      "cardholder_name",
+      "issuer_id"
+    ],
+    "min_allowed_amount": 5,
+    "max_allowed_amount": 200000,
+    "accreditation_time": 1440
+  },
+  {
+    "id": "debvisa",
+    "name": "Visa Débito",
+    "payment_type_id": "debit_card",
+    "status": "active",
+    "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/debvisa.gif",
+    "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/debvisa.gif",
+    "deferred_capture": "unsupported",
+    "settings": [
+      {
+        "bin": {
+          "pattern": "^4",
+          "exclusion_pattern": "^((477130)|(498588)|(498589)|(498590))",
+          "installments_pattern": "^4"
+        },
+        "card_number": {
+          "length": 16,
+          "validation": "standard"
+        },
+        "security_code": {
+          "mode": "mandatory",
+          "length": 3,
+          "card_location": "back"
+        }
+      }
+    ],
+    "additional_info_needed": [
+      "cardholder_name",
+      "issuer_id"
+    ],
+    "min_allowed_amount": 10,
+    "max_allowed_amount": 200000,
+    "accreditation_time": 1440
+  },
+  {
+    "id": "mercadopagocard",
+    "name": "Tarjeta MercadoPago",
+    "payment_type_id": "prepaid_card",
+    "status": "active",
+    "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/mercadopagocard.gif",
+    "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/mercadopagocard.gif",
+    "deferred_capture": "unsupported",
+    "settings": [
+      {
+        "bin": {
+          "pattern": "^539978",
+          "exclusion_pattern": null,
+          "installments_pattern": "^539978"
+        },
+        "card_number": {
+          "length": 16,
+          "validation": "standard"
+        },
+        "security_code": {
+          "mode": "mandatory",
+          "length": 3,
+          "card_location": "back"
+        }
+      }
+    ],
+    "additional_info_needed": [
+      "cardholder_name"
+    ],
+    "min_allowed_amount": 5,
+    "max_allowed_amount": 200000,
+    "accreditation_time": 1440
+  },
+  {
+    "id": "bancomer",
+    "name": "BBVA Bancomer",
+    "payment_type_id": "atm",
+    "status": "active",
+    "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/bancomer.gif",
+    "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/bancomer.gif",
+    "deferred_capture": "does_not_apply",
+    "settings": [
+    ],
+    "additional_info_needed": [
+    ],
+    "min_allowed_amount": 10,
+    "max_allowed_amount": 40000,
+    "accreditation_time": 60
+  },
+  {
+    "id": "serfin",
+    "name": "Santander",
+    "payment_type_id": "atm",
+    "status": "active",
+    "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/serfin.gif",
+    "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/serfin.gif",
+    "deferred_capture": "does_not_apply",
+    "settings": [
+    ],
+    "additional_info_needed": [
+    ],
+    "min_allowed_amount": 5,
+    "max_allowed_amount": 40000,
+    "accreditation_time": 60
+  },
+  {
+    "id": "banamex",
+    "name": "Banamex",
+    "payment_type_id": "atm",
+    "status": "active",
+    "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/banamex.gif",
+    "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/banamex.gif",
+    "deferred_capture": "does_not_apply",
+    "settings": [
+    ],
+    "additional_info_needed": [
+    ],
+    "min_allowed_amount": 5,
+    "max_allowed_amount": 40000,
+    "accreditation_time": 60
+  },
+  {
+    "id": "oxxo",
+    "name": "Oxxo",
+    "payment_type_id": "ticket",
+    "status": "active",
+    "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/oxxo.gif",
+    "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/oxxo.gif",
+    "deferred_capture": "does_not_apply",
+    "settings": [
+    ],
+    "additional_info_needed": [
+    ],
+    "min_allowed_amount": 5,
+    "max_allowed_amount": 10000,
+    "accreditation_time": 2880
+  }
+]

--- a/sdk/src/androidTest/java/com/mercadopago/GuessingCardActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/GuessingCardActivityTest.java
@@ -448,7 +448,7 @@ public class GuessingCardActivityTest {
         onView(withId(R.id.mpsdkCardholderName)).check(matches(not(isDisplayed())));
         onView(withId(R.id.mpsdkCardExpiryDate)).check(matches(not(isDisplayed())));
         onView(withId(R.id.mpsdkCardSecurityCode)).check(matches(not(isDisplayed())));
-        onView(withId(R.id.mpsdkCardIdentificationType)).check(matches((isDisplayed())));
+        onView(withId(R.id.mpsdkCardIdentificationTypeSelector)).check(matches((isDisplayed())));
         onView(withId(R.id.mpsdkCardIdentificationNumber)).check(matches((isDisplayed())));
 
         onView(withId(R.id.mpsdkCardIdentificationNumber)).check(matches(hasFocus()));
@@ -476,7 +476,7 @@ public class GuessingCardActivityTest {
         onView(withId(R.id.mpsdkCardNumber)).check(matches(not(isDisplayed())));
         onView(withId(R.id.mpsdkCardholderName)).check(matches(isDisplayed()));
         onView(withId(R.id.mpsdkCardSecurityCode)).check(matches(not(isDisplayed())));
-        onView(withId(R.id.mpsdkCardIdentificationType)).check(matches(not(isDisplayed())));
+        onView(withId(R.id.mpsdkCardIdentificationTypeSelector)).check(matches(not(isDisplayed())));
         onView(withId(R.id.mpsdkCardIdentificationNumber)).check(matches(not(isDisplayed())));
 
         onView(withId(R.id.mpsdkCardholderName)).check(matches(hasFocus()));
@@ -486,7 +486,7 @@ public class GuessingCardActivityTest {
         onView(withId(R.id.mpsdkCardNumber)).check(matches(isDisplayed()));
         onView(withId(R.id.mpsdkCardExpiryDate)).check(matches(not(isDisplayed())));
         onView(withId(R.id.mpsdkCardSecurityCode)).check(matches(not(isDisplayed())));
-        onView(withId(R.id.mpsdkCardIdentificationType)).check(matches(not(isDisplayed())));
+        onView(withId(R.id.mpsdkCardIdentificationTypeSelector)).check(matches(not(isDisplayed())));
         onView(withId(R.id.mpsdkCardIdentificationNumber)).check(matches(not(isDisplayed())));
 
         onView(withId(R.id.mpsdkCardNumber)).check(matches(hasFocus()));

--- a/sdk/src/androidTest/java/com/mercadopago/GuessingCardActivityTest.java
+++ b/sdk/src/androidTest/java/com/mercadopago/GuessingCardActivityTest.java
@@ -395,8 +395,10 @@ public class GuessingCardActivityTest {
         addInitCalls();
 
         mTestRule.launchActivity(validStartIntent);
-        onView(withId(R.id.mpsdkNextButton)).check(matches(isDisplayingAtLeast(100)));
-        onView(withId(R.id.mpsdkBackInactiveButton)).check(matches(isDisplayingAtLeast(100)));
+
+        onView(withId(R.id.mpsdkCardNumber)).perform(click());
+        onView(withId(R.id.mpsdkNextButton)).check(matches(isDisplayingAtLeast(90)));
+        onView(withId(R.id.mpsdkBackInactiveButton)).check(matches(isDisplayingAtLeast(90)));
         onView(withId(R.id.mpsdkBackButton)).check(matches(not(isDisplayed())));
         onView(withId(R.id.mpsdkCardNumber)).perform(typeText(CardTestUtils.getDummyCard("master").getCardNumber()));
         onView(withId(R.id.mpsdkNextButton)).perform(click());
@@ -1804,5 +1806,13 @@ public class GuessingCardActivityTest {
         addBankDealsCall();
         addPaymentMethodsCall();
         addIdentificationTypesCall();
+    }
+
+    private void sleep() {
+        try {
+            Thread.sleep(4000);
+        } catch (InterruptedException e) {
+
+        }
     }
 }

--- a/sdk/src/androidTest/java/com/mercadopago/test/StaticMock.java
+++ b/sdk/src/androidTest/java/com/mercadopago/test/StaticMock.java
@@ -233,6 +233,15 @@ public class StaticMock {
         }
     }
 
+    public static String getPaymentMethodListMLM() {
+        try {
+            return getFile(InstrumentationRegistry.getContext(), "mocks/payment_method_list_mlm.json");
+
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
     public static String getInvalidPayerCostsJson() {
 
         try {

--- a/sdk/src/androidTest/java/com/mercadopago/utils/CustomMatchers.java
+++ b/sdk/src/androidTest/java/com/mercadopago/utils/CustomMatchers.java
@@ -96,4 +96,23 @@ public class CustomMatchers {
             }
         };
     }
+
+//    public static Matcher<Object> withPaymentTypeId (final String paymentTypeId){
+//        return new BoundedMatcher<Object, PaymentType>(PaymentType.class) {
+//            @Override
+//            public boolean matchesSafely(PaymentType paymentType) {
+//                if (paymentType.getId().equals(PaymentTypes.DEBIT_CARD)) {
+//                    return paymentTypeId.equals("Débito");
+//                } else if (paymentType.getId().equals(PaymentTypes.CREDIT_CARD)) {
+//                    return paymentTypeId.equals("Crédito");
+//                }
+//                return false;
+//            }
+//
+//            @Override
+//            public void describeTo(Description description) {
+//                description.appendText("with payment type id: ");
+//            }
+//        };
+//    }
 }

--- a/sdk/src/main/java/com/mercadopago/GuessingCardActivity.java
+++ b/sdk/src/main/java/com/mercadopago/GuessingCardActivity.java
@@ -898,9 +898,14 @@ public class GuessingCardActivity extends FrontCardActivity {
         mPaymentTypeContainer.setVisibility(View.VISIBLE);
         ViewGroup.LayoutParams originalParams = mCardNumberEditText.getLayoutParams();
         mOriginalEditTextWidth = originalParams.width;
-        ViewGroup.LayoutParams params= mCardNumberEditText.getLayoutParams();
-        params.width = ViewGroup.LayoutParams.WRAP_CONTENT;
-        mCardNumberEditText.setLayoutParams(params);
+
+        LinearLayout.LayoutParams linearParams = (LinearLayout.LayoutParams) mCardNumberEditText.getLayoutParams();
+        //parameters for left, top, right, bottom
+        linearParams.setMargins((int) getResources().getDimension(R.dimen.mpsdk_edittext_margin_inline_form),
+                (int) getResources().getDimension(R.dimen.mpsdk_edittext_margin_top_inline_form),
+                (int) getResources().getDimension(R.dimen.mpsdk_edittext_min_margin_inline_form), 0);
+        linearParams.width = (int) getResources().getDimension(R.dimen.mpsdk_edittext_min_width_inline_form);
+        mCardNumberEditText.setLayoutParams(linearParams);
     }
 
     private boolean needsMask(CharSequence s) {

--- a/sdk/src/main/java/com/mercadopago/GuessingCardActivity.java
+++ b/sdk/src/main/java/com/mercadopago/GuessingCardActivity.java
@@ -18,6 +18,7 @@ import android.text.TextWatcher;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
@@ -129,6 +130,7 @@ public class GuessingCardActivity extends FrontCardActivity {
     private boolean mIssuerFound;
     private PaymentType mSelectedPaymentType;
     private boolean mHasToEnablePaymentTypeSpinner = false;
+    private int mOriginalEditTextWidth;
 
     @Override
     protected void onResume() {
@@ -226,7 +228,6 @@ public class GuessingCardActivity extends FrontCardActivity {
         initializeToolbar();
         setListeners();
         openKeyboard(mCardNumberEditText);
-//        mCurrentEditingEditText = CardInterface.CARD_NUMBER_INPUT;
         onCardNumberFocus();
 
         mMercadoPago = new MercadoPago.Builder()
@@ -503,25 +504,23 @@ public class GuessingCardActivity extends FrontCardActivity {
             case CARD_NUMBER_INPUT:
                 if (validateCardNumber(true)) {
                     mCardNumberInput.setVisibility(View.GONE);
+                    if (mHasToEnablePaymentTypeSpinner) {
+                        mPaymentTypeContainer.setVisibility(View.GONE);
+                    }
                     mCardholderNameInput.setVisibility(View.VISIBLE);
                     mCardExpiryDateInput.setVisibility(View.VISIBLE);
-//                    mCardHolderNameEditText.requestFocus();
                     onCardholderNameFocus();
                     return true;
                 }
                 return false;
             case CARDHOLDER_NAME_INPUT:
                 if (validateCardName(true)) {
-                    if (mHasToEnablePaymentTypeSpinner) {
-                        mPaymentTypeContainer.setVisibility(View.GONE);
-                    }
                     mCardholderNameInput.setVisibility(View.GONE);
                     if (isSecurityCodeRequired()) {
                         mSecurityCodeEditView.setVisibility(View.VISIBLE);
                     } else if (mIdentificationNumberRequired) {
                         mIdentificationTypeContainer.setVisibility(View.VISIBLE);
                     }
-//                    mCardExpiryDateEditText.requestFocus();
                     onExpiryDateFocus();
                     return true;
                 }
@@ -530,13 +529,11 @@ public class GuessingCardActivity extends FrontCardActivity {
                 if (validateExpiryDate(true)) {
                     mCardExpiryDateInput.setVisibility(View.GONE);
                     if (isSecurityCodeRequired()) {
-//                        mCardSecurityCodeEditText.requestFocus();
                         onSecurityCodeFocus();
                         if (mIdentificationNumberRequired) {
                             mIdentificationTypeContainer.setVisibility(View.VISIBLE);
                         }
                     } else if (mIdentificationNumberRequired) {
-//                        mCardIdentificationNumberEditText.requestFocus();
                         onIdentificationNumberFocus();
                         mCardIdNumberInput.setVisibility(View.VISIBLE);
                     } else {
@@ -549,7 +546,6 @@ public class GuessingCardActivity extends FrontCardActivity {
                 if (validateSecurityCode(true)) {
                     mSecurityCodeEditView.setVisibility(View.GONE);
                     if (mIdentificationNumberRequired) {
-//                        mCardIdentificationNumberEditText.requestFocus();
                         onIdentificationNumberFocus();
                         mCardIdNumberInput.setVisibility(View.VISIBLE);
                     } else {
@@ -569,20 +565,18 @@ public class GuessingCardActivity extends FrontCardActivity {
     }
 
     private void onCardNumberFocus() {
-        mFrontFragment.setFontColor();
         MPTracker.getInstance().trackScreen("CARD_NUMBER", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
         disableBackInputButton();
         checkFlipCardToFront(true);
         mCurrentEditingEditText = CARD_NUMBER_INPUT;
         mCardNumberEditText.requestFocus();
-//        openKeyboard(mCardNumberEditText);
+        mFrontFragment.setFontColor();
     }
 
     private void onCardholderNameFocus() {
         if (!validateCardNumber(true)) {
             return;
         }
-        mFrontFragment.setFontColor();
         MPTracker.getInstance().trackScreen("CARD_HOLDER_NAME", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
 
         enableBackInputButton();
@@ -590,13 +584,13 @@ public class GuessingCardActivity extends FrontCardActivity {
         checkFlipCardToFront(true);
         mCurrentEditingEditText = CARDHOLDER_NAME_INPUT;
         mCardHolderNameEditText.requestFocus();
+        mFrontFragment.setFontColor();
     }
 
     private void onExpiryDateFocus() {
         if (!validateCardName(true)) {
             return;
         }
-        mFrontFragment.setFontColor();
         MPTracker.getInstance().trackScreen("CARD_EXPIRY_DATE", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
 
         enableBackInputButton();
@@ -604,13 +598,13 @@ public class GuessingCardActivity extends FrontCardActivity {
         checkFlipCardToFront(true);
         mCurrentEditingEditText = CARD_EXPIRYDATE_INPUT;
         mCardExpiryDateEditText.requestFocus();
+        mFrontFragment.setFontColor();
     }
 
     private void onSecurityCodeFocus() {
         if (!validateExpiryDate(true)) {
             return;
         }
-        mFrontFragment.setFontColor();
         if (mCurrentEditingEditText.equals(CARD_EXPIRYDATE_INPUT) ||
                         mCurrentEditingEditText.equals(CARD_IDENTIFICATION_INPUT) ||
                         mCurrentEditingEditText.equals(CARD_SECURITYCODE_INPUT)) {
@@ -624,6 +618,7 @@ public class GuessingCardActivity extends FrontCardActivity {
                 checkFlipCardToFront(true);
             }
             mCardSecurityCodeEditText.requestFocus();
+            mFrontFragment.setFontColor();
         }
     }
 
@@ -639,6 +634,7 @@ public class GuessingCardActivity extends FrontCardActivity {
         checkTransitionCardToId();
         mCurrentEditingEditText = CARD_IDENTIFICATION_INPUT;
         mCardIdentificationNumberEditText.requestFocus();
+        mFrontFragment.setFontColor();
     }
 
 
@@ -647,10 +643,9 @@ public class GuessingCardActivity extends FrontCardActivity {
             case CARDHOLDER_NAME_INPUT:
                 if (TextUtils.isEmpty(mCardHolderName) || validateCardName(true)) {
                     if (mHasToEnablePaymentTypeSpinner) {
-                        mCardholderNameInput.setVisibility(View.GONE);
+                        mPaymentTypeContainer.setVisibility(View.VISIBLE);
                     }
                     mCardNumberInput.setVisibility(View.VISIBLE);
-//                    mCardNumberEditText.requestFocus();
                     onCardNumberFocus();
                     return true;
                 }
@@ -661,7 +656,6 @@ public class GuessingCardActivity extends FrontCardActivity {
                     if (mHasToEnablePaymentTypeSpinner) {
                         mPaymentTypeContainer.setVisibility(View.VISIBLE);
                     }
-//                    mCardHolderNameEditText.requestFocus();
                     onCardholderNameFocus();
                     return true;
                 }
@@ -669,7 +663,6 @@ public class GuessingCardActivity extends FrontCardActivity {
             case CARD_SECURITYCODE_INPUT:
                 if (TextUtils.isEmpty(mSecurityCode) || validateSecurityCode(true)) {
                     mCardExpiryDateInput.setVisibility(View.VISIBLE);
-//                    mCardExpiryDateEditText.requestFocus();
                     onExpiryDateFocus();
                     return true;
                 }
@@ -678,11 +671,9 @@ public class GuessingCardActivity extends FrontCardActivity {
                 if (TextUtils.isEmpty(mCardIdentificationNumber) || validateIdentificationNumber(true)) {
                     if (isSecurityCodeRequired()) {
                         mSecurityCodeEditView.setVisibility(View.VISIBLE);
-//                        mCardSecurityCodeEditText.requestFocus();
                         onSecurityCodeFocus();
                     } else {
                         mCardExpiryDateInput.setVisibility(View.VISIBLE);
-//                        mCardExpiryDateEditText.requestFocus();
                         onExpiryDateFocus();
                     }
                     return true;
@@ -790,7 +781,6 @@ public class GuessingCardActivity extends FrontCardActivity {
                 mCardIdentificationNumberEditText.setText(number);
             }
         }
-//        mCardNumberEditText.requestFocus();
         onCardNumberFocus();
     }
 
@@ -838,8 +828,6 @@ public class GuessingCardActivity extends FrontCardActivity {
                                     enablePaymentTypeSelection(mPaymentMethodGuessingController.getGuessedPaymentMethods());
                                 }
                                 onPaymentMethodSet(paymentMethodList.get(0));
-//                                mCardNumberEditText.requestFocus();
-//                                onCardNumberFocus();
                             }
                         } else if (paymentMethodList.size() == 0 || paymentMethodList.size() > 1) {
                             blockCardNumbersInput(mCardNumberEditText);
@@ -862,7 +850,7 @@ public class GuessingCardActivity extends FrontCardActivity {
                         mCurrentPaymentMethod = null;
                         mHasToEnablePaymentTypeSpinner = false;
                         mSelectedPaymentType = null;
-                        mPaymentTypeContainer.setVisibility(View.GONE);
+                        disablePaymentTypeSelection();
                         mCardholderNameInput.setVisibility(View.VISIBLE);
                         setSecurityCodeLocation(null);
                         setSecurityCodeRequired(true);
@@ -887,10 +875,16 @@ public class GuessingCardActivity extends FrontCardActivity {
             manageAdditionalInfoNeeded();
             mFrontFragment.populateCardNumber(getCardNumber());
             if (mCurrentEditingEditText.equals(CARD_NUMBER_INPUT)) {
-//                mCardNumberEditText.requestFocus();
                 onCardNumberFocus();
             }
         }
+    }
+
+    private void disablePaymentTypeSelection() {
+        mPaymentTypeContainer.setVisibility(View.GONE);
+        ViewGroup.LayoutParams params= mCardNumberEditText.getLayoutParams();
+        params.width = mOriginalEditTextWidth;
+        mCardNumberEditText.setLayoutParams(params);
     }
 
     private void enablePaymentTypeSelection(List<PaymentMethod> paymentMethodList) {
@@ -902,6 +896,11 @@ public class GuessingCardActivity extends FrontCardActivity {
         mSelectedPaymentType = paymentTypesList.get(0);
         mPaymentTypeSpinner.setAdapter(new PaymentTypesAdapter(getActivity(), paymentTypesList));
         mPaymentTypeContainer.setVisibility(View.VISIBLE);
+        ViewGroup.LayoutParams originalParams = mCardNumberEditText.getLayoutParams();
+        mOriginalEditTextWidth = originalParams.width;
+        ViewGroup.LayoutParams params= mCardNumberEditText.getLayoutParams();
+        params.width = ViewGroup.LayoutParams.WRAP_CONTENT;
+        mCardNumberEditText.setLayoutParams(params);
     }
 
     private boolean needsMask(CharSequence s) {
@@ -1162,8 +1161,6 @@ public class GuessingCardActivity extends FrontCardActivity {
         setErrorView(message);
         if (requestFocus) {
             mCardSecurityCodeEditText.toggleLineColorOnError(true);
-//            mCardSecurityCodeEditText.requestFocus();
-//            onSecurityCodeFocus();
         }
     }
 
@@ -1190,8 +1187,6 @@ public class GuessingCardActivity extends FrontCardActivity {
         setErrorView(message);
         if (requestFocus) {
             mCardIdentificationNumberEditText.toggleLineColorOnError(true);
-//            mCardIdentificationNumberEditText.requestFocus();
-//            onIdentificationNumberFocus();
         }
     }
 
@@ -1250,15 +1245,7 @@ public class GuessingCardActivity extends FrontCardActivity {
         mCardNumberEditText.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-//                mFrontFragment.setFontColor();
-//                if (hasFocus) {
-//                    MPTracker.getInstance().trackScreen("CARD_NUMBER", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
-//
-//                    disableBackInputButton();
-//                    openKeyboard(mCardNumberEditText);
-//                    checkFlipCardToFront(true);
-//                    mCurrentEditingEditText = CARD_NUMBER_INPUT;
-//                }
+
             }
         });
     }
@@ -1298,18 +1285,7 @@ public class GuessingCardActivity extends FrontCardActivity {
         mCardHolderNameEditText.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-//                if (!validateCardNumber(true)) {
-//                    return;
-//                }
-//                mFrontFragment.setFontColor();
-//                if (hasFocus) {
-//                    MPTracker.getInstance().trackScreen("CARD_HOLDER_NAME", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
-//
-//                    enableBackInputButton();
-//                    openKeyboard(mCardHolderNameEditText);
-//                    checkFlipCardToFront(true);
-//                    mCurrentEditingEditText = CARDHOLDER_NAME_INPUT;
-//                }
+
             }
         });
     }
@@ -1338,18 +1314,7 @@ public class GuessingCardActivity extends FrontCardActivity {
         mCardExpiryDateEditText.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-//                if (!validateCardName(true)) {
-//                    return;
-//                }
-//                mFrontFragment.setFontColor();
-//                if (hasFocus) {
-//                    MPTracker.getInstance().trackScreen("CARD_EXPIRY_DATE", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
-//
-//                    enableBackInputButton();
-//                    openKeyboard(mCardExpiryDateEditText);
-//                    checkFlipCardToFront(true);
-//                    mCurrentEditingEditText = CARD_EXPIRYDATE_INPUT;
-//                }
+
             }
         });
     }
@@ -1378,24 +1343,7 @@ public class GuessingCardActivity extends FrontCardActivity {
         mCardSecurityCodeEditText.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-//                if (!validateExpiryDate(true)) {
-//                    return;
-//                }
-//                mFrontFragment.setFontColor();
-//                if (hasFocus &&
-//                        (mCurrentEditingEditText.equals(CARD_EXPIRYDATE_INPUT) ||
-//                        mCurrentEditingEditText.equals(CARD_IDENTIFICATION_INPUT) ||
-//                        mCurrentEditingEditText.equals(CARD_SECURITYCODE_INPUT))) {
-//                    MPTracker.getInstance().trackScreen("CARD_SECURITY_CODE", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
-//                    enableBackInputButton();
-//                    openKeyboard(mCardSecurityCodeEditText);
-//                    mCurrentEditingEditText = CARD_SECURITYCODE_INPUT;
-//                    if (mSecurityCodeLocation == null || mSecurityCodeLocation.equals(CardInterface.CARD_SIDE_BACK)) {
-//                        checkFlipCardToBack(true);
-//                    } else {
-//                        checkFlipCardToFront(true);
-//                    }
-//                }
+
             }
         });
     }
@@ -1454,7 +1402,6 @@ public class GuessingCardActivity extends FrontCardActivity {
                     return false;
                 }
                 checkTransitionCardToId();
-//                mCardIdentificationNumberEditText.requestFocus();
                 onIdentificationNumberFocus();
                 return false;
             }
@@ -1482,18 +1429,7 @@ public class GuessingCardActivity extends FrontCardActivity {
         mCardIdentificationNumberEditText.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-//                if ((isSecurityCodeRequired() && !validateSecurityCode(true)) ||
-//                        (!isSecurityCodeRequired() && !validateExpiryDate(true))) {
-//                   return;
-//                }
-//                mFrontFragment.setFontColor();
-//                if (hasFocus) {
-//                    MPTracker.getInstance().trackScreen("IDENTIFICATION_NUMBER", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
-//                    enableBackInputButton();
-//                    openKeyboard(mCardIdentificationNumberEditText);
-//                    checkTransitionCardToId();
-//                    mCurrentEditingEditText = CARD_IDENTIFICATION_INPUT;
-//                }
+
             }
         });
     }
@@ -1686,7 +1622,6 @@ public class GuessingCardActivity extends FrontCardActivity {
             setErrorView(e.getMessage());
             if (requestFocus) {
                 mCardNumberEditText.toggleLineColorOnError(true);
-//                mCardNumberEditText.requestFocus();
                 onCardNumberFocus();
             }
             return false;
@@ -1705,8 +1640,6 @@ public class GuessingCardActivity extends FrontCardActivity {
             setErrorView(getString(R.string.mpsdk_invalid_empty_name));
             if (requestFocus) {
                 mCardHolderNameEditText.toggleLineColorOnError(true);
-//                mCardHolderNameEditText.requestFocus();
-//                onCardholderNameFocus();
             }
             return false;
         }
@@ -1724,8 +1657,6 @@ public class GuessingCardActivity extends FrontCardActivity {
             setErrorView(getString(R.string.mpsdk_invalid_expiry_date));
             if (requestFocus) {
                 mCardExpiryDateEditText.toggleLineColorOnError(true);
-//                mCardExpiryDateEditText.requestFocus();
-//                onExpiryDateFocus();
             }
             return false;
         }

--- a/sdk/src/main/java/com/mercadopago/GuessingCardActivity.java
+++ b/sdk/src/main/java/com/mercadopago/GuessingCardActivity.java
@@ -226,7 +226,8 @@ public class GuessingCardActivity extends FrontCardActivity {
         initializeToolbar();
         setListeners();
         openKeyboard(mCardNumberEditText);
-        mCurrentEditingEditText = CardInterface.CARD_NUMBER_INPUT;
+//        mCurrentEditingEditText = CardInterface.CARD_NUMBER_INPUT;
+        onCardNumberFocus();
 
         mMercadoPago = new MercadoPago.Builder()
                 .setContext(getActivity())
@@ -504,7 +505,8 @@ public class GuessingCardActivity extends FrontCardActivity {
                     mCardNumberInput.setVisibility(View.GONE);
                     mCardholderNameInput.setVisibility(View.VISIBLE);
                     mCardExpiryDateInput.setVisibility(View.VISIBLE);
-                    mCardHolderNameEditText.requestFocus();
+//                    mCardHolderNameEditText.requestFocus();
+                    onCardholderNameFocus();
                     return true;
                 }
                 return false;
@@ -519,7 +521,8 @@ public class GuessingCardActivity extends FrontCardActivity {
                     } else if (mIdentificationNumberRequired) {
                         mIdentificationTypeContainer.setVisibility(View.VISIBLE);
                     }
-                    mCardExpiryDateEditText.requestFocus();
+//                    mCardExpiryDateEditText.requestFocus();
+                    onExpiryDateFocus();
                     return true;
                 }
                 return false;
@@ -527,12 +530,14 @@ public class GuessingCardActivity extends FrontCardActivity {
                 if (validateExpiryDate(true)) {
                     mCardExpiryDateInput.setVisibility(View.GONE);
                     if (isSecurityCodeRequired()) {
-                        mCardSecurityCodeEditText.requestFocus();
+//                        mCardSecurityCodeEditText.requestFocus();
+                        onSecurityCodeFocus();
                         if (mIdentificationNumberRequired) {
                             mIdentificationTypeContainer.setVisibility(View.VISIBLE);
                         }
                     } else if (mIdentificationNumberRequired) {
-                        mCardIdentificationNumberEditText.requestFocus();
+//                        mCardIdentificationNumberEditText.requestFocus();
+                        onIdentificationNumberFocus();
                         mCardIdNumberInput.setVisibility(View.VISIBLE);
                     } else {
                         createToken();
@@ -544,7 +549,8 @@ public class GuessingCardActivity extends FrontCardActivity {
                 if (validateSecurityCode(true)) {
                     mSecurityCodeEditView.setVisibility(View.GONE);
                     if (mIdentificationNumberRequired) {
-                        mCardIdentificationNumberEditText.requestFocus();
+//                        mCardIdentificationNumberEditText.requestFocus();
+                        onIdentificationNumberFocus();
                         mCardIdNumberInput.setVisibility(View.VISIBLE);
                     } else {
                         createToken();
@@ -562,6 +568,80 @@ public class GuessingCardActivity extends FrontCardActivity {
         return false;
     }
 
+    private void onCardNumberFocus() {
+        mFrontFragment.setFontColor();
+        MPTracker.getInstance().trackScreen("CARD_NUMBER", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
+        disableBackInputButton();
+        checkFlipCardToFront(true);
+        mCurrentEditingEditText = CARD_NUMBER_INPUT;
+        mCardNumberEditText.requestFocus();
+//        openKeyboard(mCardNumberEditText);
+    }
+
+    private void onCardholderNameFocus() {
+        if (!validateCardNumber(true)) {
+            return;
+        }
+        mFrontFragment.setFontColor();
+        MPTracker.getInstance().trackScreen("CARD_HOLDER_NAME", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
+
+        enableBackInputButton();
+        openKeyboard(mCardHolderNameEditText);
+        checkFlipCardToFront(true);
+        mCurrentEditingEditText = CARDHOLDER_NAME_INPUT;
+        mCardHolderNameEditText.requestFocus();
+    }
+
+    private void onExpiryDateFocus() {
+        if (!validateCardName(true)) {
+            return;
+        }
+        mFrontFragment.setFontColor();
+        MPTracker.getInstance().trackScreen("CARD_EXPIRY_DATE", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
+
+        enableBackInputButton();
+        openKeyboard(mCardExpiryDateEditText);
+        checkFlipCardToFront(true);
+        mCurrentEditingEditText = CARD_EXPIRYDATE_INPUT;
+        mCardExpiryDateEditText.requestFocus();
+    }
+
+    private void onSecurityCodeFocus() {
+        if (!validateExpiryDate(true)) {
+            return;
+        }
+        mFrontFragment.setFontColor();
+        if (mCurrentEditingEditText.equals(CARD_EXPIRYDATE_INPUT) ||
+                        mCurrentEditingEditText.equals(CARD_IDENTIFICATION_INPUT) ||
+                        mCurrentEditingEditText.equals(CARD_SECURITYCODE_INPUT)) {
+            MPTracker.getInstance().trackScreen("CARD_SECURITY_CODE", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
+            enableBackInputButton();
+            openKeyboard(mCardSecurityCodeEditText);
+            mCurrentEditingEditText = CARD_SECURITYCODE_INPUT;
+            if (mSecurityCodeLocation == null || mSecurityCodeLocation.equals(CardInterface.CARD_SIDE_BACK)) {
+                checkFlipCardToBack(true);
+            } else {
+                checkFlipCardToFront(true);
+            }
+            mCardSecurityCodeEditText.requestFocus();
+        }
+    }
+
+    private void onIdentificationNumberFocus() {
+        if ((isSecurityCodeRequired() && !validateSecurityCode(true)) ||
+                (!isSecurityCodeRequired() && !validateExpiryDate(true))) {
+            return;
+        }
+        mFrontFragment.setFontColor();
+        MPTracker.getInstance().trackScreen("IDENTIFICATION_NUMBER", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
+        enableBackInputButton();
+        openKeyboard(mCardIdentificationNumberEditText);
+        checkTransitionCardToId();
+        mCurrentEditingEditText = CARD_IDENTIFICATION_INPUT;
+        mCardIdentificationNumberEditText.requestFocus();
+    }
+
+
     private boolean checkIsEmptyOrValid() {
         switch (mCurrentEditingEditText) {
             case CARDHOLDER_NAME_INPUT:
@@ -570,7 +650,8 @@ public class GuessingCardActivity extends FrontCardActivity {
                         mCardholderNameInput.setVisibility(View.GONE);
                     }
                     mCardNumberInput.setVisibility(View.VISIBLE);
-                    mCardNumberEditText.requestFocus();
+//                    mCardNumberEditText.requestFocus();
+                    onCardNumberFocus();
                     return true;
                 }
                 return false;
@@ -580,14 +661,16 @@ public class GuessingCardActivity extends FrontCardActivity {
                     if (mHasToEnablePaymentTypeSpinner) {
                         mPaymentTypeContainer.setVisibility(View.VISIBLE);
                     }
-                    mCardHolderNameEditText.requestFocus();
+//                    mCardHolderNameEditText.requestFocus();
+                    onCardholderNameFocus();
                     return true;
                 }
                 return false;
             case CARD_SECURITYCODE_INPUT:
                 if (TextUtils.isEmpty(mSecurityCode) || validateSecurityCode(true)) {
                     mCardExpiryDateInput.setVisibility(View.VISIBLE);
-                    mCardExpiryDateEditText.requestFocus();
+//                    mCardExpiryDateEditText.requestFocus();
+                    onExpiryDateFocus();
                     return true;
                 }
                 return false;
@@ -595,10 +678,12 @@ public class GuessingCardActivity extends FrontCardActivity {
                 if (TextUtils.isEmpty(mCardIdentificationNumber) || validateIdentificationNumber(true)) {
                     if (isSecurityCodeRequired()) {
                         mSecurityCodeEditView.setVisibility(View.VISIBLE);
-                        mCardSecurityCodeEditText.requestFocus();
+//                        mCardSecurityCodeEditText.requestFocus();
+                        onSecurityCodeFocus();
                     } else {
                         mCardExpiryDateInput.setVisibility(View.VISIBLE);
-                        mCardExpiryDateEditText.requestFocus();
+//                        mCardExpiryDateEditText.requestFocus();
+                        onExpiryDateFocus();
                     }
                     return true;
                 }
@@ -705,7 +790,8 @@ public class GuessingCardActivity extends FrontCardActivity {
                 mCardIdentificationNumberEditText.setText(number);
             }
         }
-        mCardNumberEditText.requestFocus();
+//        mCardNumberEditText.requestFocus();
+        onCardNumberFocus();
     }
 
     protected void initializeGuessingCardNumberController() {
@@ -752,7 +838,8 @@ public class GuessingCardActivity extends FrontCardActivity {
                                     enablePaymentTypeSelection(mPaymentMethodGuessingController.getGuessedPaymentMethods());
                                 }
                                 onPaymentMethodSet(paymentMethodList.get(0));
-                                mCardNumberEditText.requestFocus();
+//                                mCardNumberEditText.requestFocus();
+//                                onCardNumberFocus();
                             }
                         } else if (paymentMethodList.size() == 0 || paymentMethodList.size() > 1) {
                             blockCardNumbersInput(mCardNumberEditText);
@@ -799,6 +886,10 @@ public class GuessingCardActivity extends FrontCardActivity {
             manageSettings();
             manageAdditionalInfoNeeded();
             mFrontFragment.populateCardNumber(getCardNumber());
+            if (mCurrentEditingEditText.equals(CARD_NUMBER_INPUT)) {
+//                mCardNumberEditText.requestFocus();
+                onCardNumberFocus();
+            }
         }
     }
 
@@ -1071,7 +1162,8 @@ public class GuessingCardActivity extends FrontCardActivity {
         setErrorView(message);
         if (requestFocus) {
             mCardSecurityCodeEditText.toggleLineColorOnError(true);
-            mCardSecurityCodeEditText.requestFocus();
+//            mCardSecurityCodeEditText.requestFocus();
+//            onSecurityCodeFocus();
         }
     }
 
@@ -1098,7 +1190,8 @@ public class GuessingCardActivity extends FrontCardActivity {
         setErrorView(message);
         if (requestFocus) {
             mCardIdentificationNumberEditText.toggleLineColorOnError(true);
-            mCardIdentificationNumberEditText.requestFocus();
+//            mCardIdentificationNumberEditText.requestFocus();
+//            onIdentificationNumberFocus();
         }
     }
 
@@ -1157,15 +1250,15 @@ public class GuessingCardActivity extends FrontCardActivity {
         mCardNumberEditText.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-                mFrontFragment.setFontColor();
-                if (hasFocus) {
-                    MPTracker.getInstance().trackScreen("CARD_NUMBER", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
-
-                    disableBackInputButton();
-                    openKeyboard(mCardNumberEditText);
-                    checkFlipCardToFront(true);
-                    mCurrentEditingEditText = CARD_NUMBER_INPUT;
-                }
+//                mFrontFragment.setFontColor();
+//                if (hasFocus) {
+//                    MPTracker.getInstance().trackScreen("CARD_NUMBER", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
+//
+//                    disableBackInputButton();
+//                    openKeyboard(mCardNumberEditText);
+//                    checkFlipCardToFront(true);
+//                    mCurrentEditingEditText = CARD_NUMBER_INPUT;
+//                }
             }
         });
     }
@@ -1205,18 +1298,18 @@ public class GuessingCardActivity extends FrontCardActivity {
         mCardHolderNameEditText.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-                if (!validateCardNumber(true)) {
-                    return;
-                }
-                mFrontFragment.setFontColor();
-                if (hasFocus) {
-                    MPTracker.getInstance().trackScreen("CARD_HOLDER_NAME", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
-
-                    enableBackInputButton();
-                    openKeyboard(mCardHolderNameEditText);
-                    checkFlipCardToFront(true);
-                    mCurrentEditingEditText = CARDHOLDER_NAME_INPUT;
-                }
+//                if (!validateCardNumber(true)) {
+//                    return;
+//                }
+//                mFrontFragment.setFontColor();
+//                if (hasFocus) {
+//                    MPTracker.getInstance().trackScreen("CARD_HOLDER_NAME", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
+//
+//                    enableBackInputButton();
+//                    openKeyboard(mCardHolderNameEditText);
+//                    checkFlipCardToFront(true);
+//                    mCurrentEditingEditText = CARDHOLDER_NAME_INPUT;
+//                }
             }
         });
     }
@@ -1245,18 +1338,18 @@ public class GuessingCardActivity extends FrontCardActivity {
         mCardExpiryDateEditText.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-                if (!validateCardName(true)) {
-                    return;
-                }
-                mFrontFragment.setFontColor();
-                if (hasFocus) {
-                    MPTracker.getInstance().trackScreen("CARD_EXPIRY_DATE", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
-
-                    enableBackInputButton();
-                    openKeyboard(mCardExpiryDateEditText);
-                    checkFlipCardToFront(true);
-                    mCurrentEditingEditText = CARD_EXPIRYDATE_INPUT;
-                }
+//                if (!validateCardName(true)) {
+//                    return;
+//                }
+//                mFrontFragment.setFontColor();
+//                if (hasFocus) {
+//                    MPTracker.getInstance().trackScreen("CARD_EXPIRY_DATE", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
+//
+//                    enableBackInputButton();
+//                    openKeyboard(mCardExpiryDateEditText);
+//                    checkFlipCardToFront(true);
+//                    mCurrentEditingEditText = CARD_EXPIRYDATE_INPUT;
+//                }
             }
         });
     }
@@ -1285,24 +1378,24 @@ public class GuessingCardActivity extends FrontCardActivity {
         mCardSecurityCodeEditText.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-                if (!validateExpiryDate(true)) {
-                    return;
-                }
-                mFrontFragment.setFontColor();
-                if (hasFocus &&
-                        (mCurrentEditingEditText.equals(CARD_EXPIRYDATE_INPUT) ||
-                        mCurrentEditingEditText.equals(CARD_IDENTIFICATION_INPUT) ||
-                        mCurrentEditingEditText.equals(CARD_SECURITYCODE_INPUT))) {
-                    MPTracker.getInstance().trackScreen("CARD_SECURITY_CODE", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
-                    enableBackInputButton();
-                    openKeyboard(mCardSecurityCodeEditText);
-                    mCurrentEditingEditText = CARD_SECURITYCODE_INPUT;
-                    if (mSecurityCodeLocation == null || mSecurityCodeLocation.equals(CardInterface.CARD_SIDE_BACK)) {
-                        checkFlipCardToBack(true);
-                    } else {
-                        checkFlipCardToFront(true);
-                    }
-                }
+//                if (!validateExpiryDate(true)) {
+//                    return;
+//                }
+//                mFrontFragment.setFontColor();
+//                if (hasFocus &&
+//                        (mCurrentEditingEditText.equals(CARD_EXPIRYDATE_INPUT) ||
+//                        mCurrentEditingEditText.equals(CARD_IDENTIFICATION_INPUT) ||
+//                        mCurrentEditingEditText.equals(CARD_SECURITYCODE_INPUT))) {
+//                    MPTracker.getInstance().trackScreen("CARD_SECURITY_CODE", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
+//                    enableBackInputButton();
+//                    openKeyboard(mCardSecurityCodeEditText);
+//                    mCurrentEditingEditText = CARD_SECURITYCODE_INPUT;
+//                    if (mSecurityCodeLocation == null || mSecurityCodeLocation.equals(CardInterface.CARD_SIDE_BACK)) {
+//                        checkFlipCardToBack(true);
+//                    } else {
+//                        checkFlipCardToFront(true);
+//                    }
+//                }
             }
         });
     }
@@ -1361,7 +1454,8 @@ public class GuessingCardActivity extends FrontCardActivity {
                     return false;
                 }
                 checkTransitionCardToId();
-                mCardIdentificationNumberEditText.requestFocus();
+//                mCardIdentificationNumberEditText.requestFocus();
+                onIdentificationNumberFocus();
                 return false;
             }
         });
@@ -1388,18 +1482,18 @@ public class GuessingCardActivity extends FrontCardActivity {
         mCardIdentificationNumberEditText.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-                if ((isSecurityCodeRequired() && !validateSecurityCode(true)) ||
-                        (!isSecurityCodeRequired() && !validateExpiryDate(true))) {
-                   return;
-                }
-                mFrontFragment.setFontColor();
-                if (hasFocus) {
-                    MPTracker.getInstance().trackScreen("IDENTIFICATION_NUMBER", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
-                    enableBackInputButton();
-                    openKeyboard(mCardIdentificationNumberEditText);
-                    checkTransitionCardToId();
-                    mCurrentEditingEditText = CARD_IDENTIFICATION_INPUT;
-                }
+//                if ((isSecurityCodeRequired() && !validateSecurityCode(true)) ||
+//                        (!isSecurityCodeRequired() && !validateExpiryDate(true))) {
+//                   return;
+//                }
+//                mFrontFragment.setFontColor();
+//                if (hasFocus) {
+//                    MPTracker.getInstance().trackScreen("IDENTIFICATION_NUMBER", 2, mPublicKey, BuildConfig.VERSION_NAME, getActivity());
+//                    enableBackInputButton();
+//                    openKeyboard(mCardIdentificationNumberEditText);
+//                    checkTransitionCardToId();
+//                    mCurrentEditingEditText = CARD_IDENTIFICATION_INPUT;
+//                }
             }
         });
     }
@@ -1592,7 +1686,8 @@ public class GuessingCardActivity extends FrontCardActivity {
             setErrorView(e.getMessage());
             if (requestFocus) {
                 mCardNumberEditText.toggleLineColorOnError(true);
-                mCardNumberEditText.requestFocus();
+//                mCardNumberEditText.requestFocus();
+                onCardNumberFocus();
             }
             return false;
         }
@@ -1610,7 +1705,8 @@ public class GuessingCardActivity extends FrontCardActivity {
             setErrorView(getString(R.string.mpsdk_invalid_empty_name));
             if (requestFocus) {
                 mCardHolderNameEditText.toggleLineColorOnError(true);
-                mCardHolderNameEditText.requestFocus();
+//                mCardHolderNameEditText.requestFocus();
+//                onCardholderNameFocus();
             }
             return false;
         }
@@ -1628,7 +1724,8 @@ public class GuessingCardActivity extends FrontCardActivity {
             setErrorView(getString(R.string.mpsdk_invalid_expiry_date));
             if (requestFocus) {
                 mCardExpiryDateEditText.toggleLineColorOnError(true);
-                mCardExpiryDateEditText.requestFocus();
+//                mCardExpiryDateEditText.requestFocus();
+//                onExpiryDateFocus();
             }
             return false;
         }

--- a/sdk/src/main/java/com/mercadopago/GuessingCardActivity.java
+++ b/sdk/src/main/java/com/mercadopago/GuessingCardActivity.java
@@ -31,9 +31,11 @@ import android.widget.TextView;
 
 import com.google.gson.reflect.TypeToken;
 import com.mercadopago.adapters.IdentificationTypesAdapter;
+import com.mercadopago.adapters.PaymentTypeIdsAdapter;
 import com.mercadopago.callbacks.Callback;
 import com.mercadopago.callbacks.FailureRecovery;
 import com.mercadopago.callbacks.PaymentMethodSelectionCallback;
+import com.mercadopago.constants.PaymentTypes;
 import com.mercadopago.controllers.PaymentMethodGuessingController;
 import com.mercadopago.core.MercadoPago;
 import com.mercadopago.fragments.CardBackFragment;
@@ -62,6 +64,7 @@ import com.mercadopago.views.MPEditText;
 import com.mercadopago.views.MPTextView;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 
 public class GuessingCardActivity extends FrontCardActivity {
@@ -82,8 +85,10 @@ public class GuessingCardActivity extends FrontCardActivity {
     private LinearLayout mSecurityCodeEditView;
     private LinearLayout mInputContainer;
     private Spinner mIdentificationTypeSpinner;
+    private Spinner mPaymentTypeSpinner;
     private LinearLayout mIdentificationTypeContainer;
     private LinearLayout mIdentificationNumberContainer;
+    private LinearLayout mPaymentTypeContainer;
     private ScrollView mScrollView;
     private ProgressBar mProgressBar;
     private FrameLayout mBackButton;
@@ -122,6 +127,7 @@ public class GuessingCardActivity extends FrontCardActivity {
     private int mCardNumberLength;
     private String mSecurityCodeLocation;
     private boolean mIssuerFound;
+    private String mSelectedPaymentType;
 
     @Override
     protected void onResume() {
@@ -308,6 +314,8 @@ public class GuessingCardActivity extends FrontCardActivity {
         mIdentificationTypeSpinner = (Spinner) findViewById(R.id.mpsdkCardIdentificationType);
         mIdentificationTypeContainer = (LinearLayout) findViewById(R.id.mpsdkCardIdentificationTypeContainer);
         mIdentificationNumberContainer = (LinearLayout) findViewById(R.id.mpsdkCardIdentificationNumberContainer);
+        mPaymentTypeContainer = (LinearLayout) findViewById(R.id.mpsdkCardPaymentMethodSelectionContainer);
+        mPaymentTypeSpinner = (Spinner) findViewById(R.id.mpsdkCardPaymentMethodSelector);
         mProgressBar = (ProgressBar) findViewById(R.id.mpsdkProgressBar);
         mBackButton = (FrameLayout) findViewById(R.id.mpsdkBackButton);
         mNextButton = (FrameLayout) findViewById(R.id.mpsdkNextButton);
@@ -323,6 +331,7 @@ public class GuessingCardActivity extends FrontCardActivity {
         mProgressBar.setVisibility(View.GONE);
         mIdentificationTypeContainer.setVisibility(View.GONE);
         mIdentificationNumberContainer.setVisibility(View.GONE);
+        mPaymentTypeContainer.setVisibility(View.GONE);
         mButtonContainer.setVisibility(View.VISIBLE);
 
         mCardBackground = findViewById(R.id.mpsdkCardBackground);
@@ -726,7 +735,9 @@ public class GuessingCardActivity extends FrontCardActivity {
                 new PaymentMethodSelectionCallback() {
                     @Override
                     public void onPaymentMethodListSet(List<PaymentMethod> paymentMethodList) {
-                        if (paymentMethodList.size() == 0 || paymentMethodList.size() > 1) {
+                        if (paymentMethodList.size() == 2) {
+                            enablePaymentTypeSelection(paymentMethodList);
+                        } else if (paymentMethodList.size() == 0 || paymentMethodList.size() > 1) {
                             blockCardNumbersInput(mCardNumberEditText);
                             setErrorView(getString(R.string.mpsdk_invalid_payment_method));
                         } else {
@@ -764,6 +775,19 @@ public class GuessingCardActivity extends FrontCardActivity {
                     }
 
                 }));
+    }
+
+    private void enablePaymentTypeSelection(List<PaymentMethod> paymentMethodList) {
+        mPaymentTypeContainer.setVisibility(View.VISIBLE);
+        List<String> paymentTypeIds = new ArrayList<>();
+        for (PaymentMethod pm: paymentMethodList) {
+            paymentTypeIds.add(PaymentTypes.getString(pm.getPaymentTypeId(), getActivity());
+        }
+        mSelectedPaymentType = paymentTypeIds.get(0);
+        mPaymentTypeSpinner.setAdapter(new PaymentTypeIdsAdapter(getActivity(), paymentTypeIds));
+
+        mIdentificationTypeSpinner.setAdapter(new IdentificationTypesAdapter(getActivity(), identificationTypes));
+        mIdentificationTypeContainer.setVisibility(View.VISIBLE);
     }
 
     private boolean needsMask(CharSequence s) {

--- a/sdk/src/main/java/com/mercadopago/adapters/PaymentTypeIdsAdapter.java
+++ b/sdk/src/main/java/com/mercadopago/adapters/PaymentTypeIdsAdapter.java
@@ -1,0 +1,64 @@
+package com.mercadopago.adapters;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+
+import com.mercadopago.R;
+import com.mercadopago.model.IdentificationType;
+import com.mercadopago.views.MPTextView;
+
+import java.util.List;
+
+/**
+ * Created by vaserber on 9/22/16.
+ */
+
+public class PaymentTypeIdsAdapter extends BaseAdapter {
+
+    private List<String> mData;
+    private static LayoutInflater mInflater = null;
+
+    public PaymentTypeIdsAdapter(Activity activity, List<String> data) {
+        mData = data;
+        mInflater = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+    }
+
+    public int getCount() {
+        return mData.size();
+    }
+
+    public Object getItem(int position) {
+        try {
+            return mData.get(position);
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    public List<String> getPaymentTypeIds() {
+        return mData;
+    }
+
+    public long getItemId(int position) {
+        return position;
+    }
+
+    public View getView(int position, View convertView, ViewGroup parent) {
+
+        View row = convertView;
+
+        if (convertView == null)
+            row = mInflater.inflate(R.layout.mpsdk_row_simple_spinner, parent, false);
+
+        String paymentTypeId = mData.get(position);
+
+        MPTextView label = (MPTextView) row.findViewById(R.id.mpsdkLabel);
+        label.setText(paymentTypeId);
+
+        return row;
+    }
+}

--- a/sdk/src/main/java/com/mercadopago/adapters/PaymentTypesAdapter.java
+++ b/sdk/src/main/java/com/mercadopago/adapters/PaymentTypesAdapter.java
@@ -9,6 +9,7 @@ import android.widget.BaseAdapter;
 
 import com.mercadopago.R;
 import com.mercadopago.model.IdentificationType;
+import com.mercadopago.model.PaymentType;
 import com.mercadopago.views.MPTextView;
 
 import java.util.List;
@@ -17,14 +18,16 @@ import java.util.List;
  * Created by vaserber on 9/22/16.
  */
 
-public class PaymentTypeIdsAdapter extends BaseAdapter {
+public class PaymentTypesAdapter extends BaseAdapter {
 
-    private List<String> mData;
+    private List<PaymentType> mData;
     private static LayoutInflater mInflater = null;
+    private Context mContext;
 
-    public PaymentTypeIdsAdapter(Activity activity, List<String> data) {
+    public PaymentTypesAdapter(Activity activity, List<PaymentType> data) {
         mData = data;
         mInflater = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        mContext = activity;
     }
 
     public int getCount() {
@@ -39,7 +42,7 @@ public class PaymentTypeIdsAdapter extends BaseAdapter {
         }
     }
 
-    public List<String> getPaymentTypeIds() {
+    public List<PaymentType> getPaymentTypes() {
         return mData;
     }
 
@@ -54,10 +57,10 @@ public class PaymentTypeIdsAdapter extends BaseAdapter {
         if (convertView == null)
             row = mInflater.inflate(R.layout.mpsdk_row_simple_spinner, parent, false);
 
-        String paymentTypeId = mData.get(position);
+        PaymentType paymentType = mData.get(position);
 
         MPTextView label = (MPTextView) row.findViewById(R.id.mpsdkLabel);
-        label.setText(paymentTypeId);
+        label.setText(paymentType.toString(mContext));
 
         return row;
     }

--- a/sdk/src/main/java/com/mercadopago/constants/PaymentTypes.java
+++ b/sdk/src/main/java/com/mercadopago/constants/PaymentTypes.java
@@ -1,5 +1,9 @@
 package com.mercadopago.constants;
 
+import android.content.Context;
+
+import com.mercadopago.R;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,5 +33,15 @@ public class PaymentTypes {
             add(DIGITAL_CURRENCY);
             add(BANK_TRANSFER);
         }};
+    }
+
+    public static String getString(String paymentType, Context context) {
+        String ans = null;
+        if (paymentType.equals(CREDIT_CARD)) {
+            ans = context.getString(R.string.mpsdk_credit_card);
+        } else if (paymentType.equals(DEBIT_CARD)) {
+            ans = context.getString(R.string.mpsdk_debit_card);
+        }
+        return ans;
     }
 }

--- a/sdk/src/main/java/com/mercadopago/constants/PaymentTypes.java
+++ b/sdk/src/main/java/com/mercadopago/constants/PaymentTypes.java
@@ -35,13 +35,4 @@ public class PaymentTypes {
         }};
     }
 
-    public static String getString(String paymentType, Context context) {
-        String ans = null;
-        if (paymentType.equals(CREDIT_CARD)) {
-            ans = context.getString(R.string.mpsdk_credit_card);
-        } else if (paymentType.equals(DEBIT_CARD)) {
-            ans = context.getString(R.string.mpsdk_debit_card);
-        }
-        return ans;
-    }
 }

--- a/sdk/src/main/java/com/mercadopago/controllers/PaymentMethodGuessingController.java
+++ b/sdk/src/main/java/com/mercadopago/controllers/PaymentMethodGuessingController.java
@@ -22,6 +22,10 @@ public class PaymentMethodGuessingController {
         this.mSavedBin = "";
     }
 
+    public List<PaymentMethod> getGuessedPaymentMethods() {
+        return mGuessedPaymentMethods;
+    }
+
     public String getPaymentTypeId() {
         return mPaymentTypeId;
     }

--- a/sdk/src/main/java/com/mercadopago/model/PaymentType.java
+++ b/sdk/src/main/java/com/mercadopago/model/PaymentType.java
@@ -1,5 +1,10 @@
 package com.mercadopago.model;
 
+import android.content.Context;
+
+import com.mercadopago.R;
+import com.mercadopago.constants.PaymentTypes;
+
 /**
  * Created by mreverter on 15/1/16.
  */
@@ -7,11 +12,28 @@ public class PaymentType {
 
     private String id;
 
+    public PaymentType() {
+
+    }
+
+    public PaymentType(String id) {
+        this.id = id;
+    }
     public String getId() {
         return id;
     }
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String toString(Context context) {
+        String ans = "";
+        if (id.equals(PaymentTypes.CREDIT_CARD)) {
+            ans = context.getString(R.string.mpsdk_credit_card);
+        } else if (id.equals(PaymentTypes.DEBIT_CARD)) {
+            ans = context.getString(R.string.mpsdk_debit_card);
+        }
+        return ans;
     }
 }

--- a/sdk/src/main/res/layout/mpsdk_new_card_input.xml
+++ b/sdk/src/main/res/layout/mpsdk_new_card_input.xml
@@ -42,32 +42,21 @@
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/mpsdkCardPaymentMethodSelectionContainer"
+        android:id="@+id/mpsdkCardPaymentTypeSelectionContainer"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:visibility="gone">
 
-        <com.mercadopago.views.MPTextView
-            android:id="@+id/mpsdkPaymentMethodSelectorText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:textSize="14dp"
-            android:lines="1"
-            android:textColor="@color/mpsdk_color_new_card_text"
-            android:text="@string/mpsdk_card_identification_type"/>
-
         <Spinner
-            android:id="@+id/mpsdkCardPaymentMethodSelector"
+            android:id="@+id/mpsdkCardPaymentTypeSelector"
             android:layout_width="100dp"
             android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
             android:paddingLeft="5dp"
             android:paddingStart="5dp"
             android:paddingEnd="5dp"
-            android:paddingRight="5dp"
-            style="@style/Widget.AppCompat.Spinner.Underlined"/>
+            android:paddingRight="5dp"/>
     </LinearLayout>
 
 
@@ -192,7 +181,7 @@
 
         <!-- spinner -->
         <Spinner
-            android:id="@+id/mpsdkCardIdentificationType"
+            android:id="@+id/mpsdkCardIdentificationTypeSelector"
             android:layout_width="100dp"
             android:layout_height="36dp"/>
 

--- a/sdk/src/main/res/layout/mpsdk_new_card_input.xml
+++ b/sdk/src/main/res/layout/mpsdk_new_card_input.xml
@@ -25,7 +25,7 @@
             android:text="@string/mpsdk_card_number_label"/>
         <com.mercadopago.views.MPEditText
             android:id="@+id/mpsdkCardNumber"
-            android:layout_width="293dp"
+            android:layout_width="@dimen/mpsdk_edittext_width_inline_form"
             android:layout_height="wrap_content"
             android:layout_marginLeft="15dp"
             android:layout_marginRight="15dp"
@@ -78,7 +78,7 @@
             android:text="@string/mpsdk_cardholder_name"/>
         <com.mercadopago.views.MPEditText
             android:id="@+id/mpsdkCardholderName"
-            android:layout_width="293dp"
+            android:layout_width="@dimen/mpsdk_edittext_width_inline_form"
             android:layout_height="wrap_content"
             android:layout_marginLeft="15dp"
             android:layout_marginRight="15dp"
@@ -112,7 +112,7 @@
             android:text="@string/mpsdk_card_expire_date_label"/>
         <com.mercadopago.views.MPEditText
             android:id="@+id/mpsdkCardExpiryDate"
-            android:layout_width="293dp"
+            android:layout_width="@dimen/mpsdk_edittext_width_inline_form"
             android:layout_height="wrap_content"
             android:layout_marginLeft="15dp"
             android:layout_marginRight="15dp"
@@ -147,7 +147,7 @@
 
         <com.mercadopago.views.MPEditText
             android:id="@+id/mpsdkCardSecurityCode"
-            android:layout_width="293dp"
+            android:layout_width="@dimen/mpsdk_edittext_width_inline_form"
             android:layout_height="wrap_content"
             android:layout_marginLeft="15dp"
             android:layout_marginRight="15dp"

--- a/sdk/src/main/res/layout/mpsdk_new_card_input.xml
+++ b/sdk/src/main/res/layout/mpsdk_new_card_input.xml
@@ -42,6 +42,36 @@
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/mpsdkCardPaymentMethodSelectionContainer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <com.mercadopago.views.MPTextView
+            android:id="@+id/mpsdkPaymentMethodSelectorText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="16dp"
+            android:layout_marginStart="16dp"
+            android:textSize="14dp"
+            android:lines="1"
+            android:textColor="@color/mpsdk_color_new_card_text"
+            android:text="@string/mpsdk_card_identification_type"/>
+
+        <Spinner
+            android:id="@+id/mpsdkCardPaymentMethodSelector"
+            android:layout_width="100dp"
+            android:layout_height="wrap_content"
+            android:paddingLeft="5dp"
+            android:paddingStart="5dp"
+            android:paddingEnd="5dp"
+            android:paddingRight="5dp"
+            style="@style/Widget.AppCompat.Spinner.Underlined"/>
+    </LinearLayout>
+
+
+    <LinearLayout
         android:id="@+id/mpsdkCardholderNameInput"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -141,35 +171,6 @@
             android:textColor="@color/abc_search_url_text_selected"
             custom:errorColor="@color/mpsdk_color_red_error"/>
 
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/mpsdkCardPaymentMethodSelectionContainer"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:visibility="gone">
-
-        <com.mercadopago.views.MPTextView
-            android:id="@+id/mpsdkPaymentMethodSelectorText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:textSize="14dp"
-            android:lines="1"
-            android:textColor="@color/mpsdk_color_new_card_text"
-            android:text="@string/mpsdk_card_identification_type"/>
-
-        <Spinner
-            android:id="@+id/mpsdkCardPaymentMethodSelector"
-            android:layout_width="100dp"
-            android:layout_height="wrap_content"
-            android:paddingLeft="5dp"
-            android:paddingStart="5dp"
-            android:paddingEnd="5dp"
-            android:paddingRight="5dp"
-            style="@style/Widget.AppCompat.Spinner.Underlined"/>
     </LinearLayout>
 
     <LinearLayout

--- a/sdk/src/main/res/layout/mpsdk_new_card_input.xml
+++ b/sdk/src/main/res/layout/mpsdk_new_card_input.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:custom="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_marginTop="12dp"
     android:layout_height="wrap_content"
     android:orientation="horizontal">
@@ -27,9 +27,9 @@
             android:id="@+id/mpsdkCardNumber"
             android:layout_width="@dimen/mpsdk_edittext_width_inline_form"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="15dp"
-            android:layout_marginRight="15dp"
-            android:layout_marginTop="2dp"
+            android:layout_marginLeft="@dimen/mpsdk_edittext_margin_inline_form"
+            android:layout_marginRight="@dimen/mpsdk_edittext_margin_inline_form"
+            android:layout_marginTop="@dimen/mpsdk_edittext_margin_top_inline_form"
             android:textSize="19dp"
             android:textColor="@color/abc_search_url_text_selected"
             android:inputType="number"
@@ -37,6 +37,7 @@
             android:imeOptions="actionNext"
             android:singleLine="true"
             android:maxLength="19"
+            tools:text="5031 7557 3453 0604"
             custom:errorColor="@color/mpsdk_color_red_error"/>
 
     </LinearLayout>
@@ -50,11 +51,11 @@
 
         <Spinner
             android:id="@+id/mpsdkCardPaymentTypeSelector"
-            android:layout_width="100dp"
+            android:layout_width="80dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
-            android:paddingLeft="5dp"
-            android:paddingStart="5dp"
+            android:paddingLeft="2dp"
+            android:paddingStart="2dp"
             android:paddingEnd="5dp"
             android:paddingRight="5dp"/>
     </LinearLayout>
@@ -80,8 +81,8 @@
             android:id="@+id/mpsdkCardholderName"
             android:layout_width="@dimen/mpsdk_edittext_width_inline_form"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="15dp"
-            android:layout_marginRight="15dp"
+            android:layout_marginLeft="@dimen/mpsdk_edittext_margin_inline_form"
+            android:layout_marginRight="@dimen/mpsdk_edittext_margin_inline_form"
             android:layout_marginTop="2dp"
             android:maxLength="50"
             android:singleLine="true"
@@ -114,8 +115,8 @@
             android:id="@+id/mpsdkCardExpiryDate"
             android:layout_width="@dimen/mpsdk_edittext_width_inline_form"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="15dp"
-            android:layout_marginRight="15dp"
+            android:layout_marginLeft="@dimen/mpsdk_edittext_margin_inline_form"
+            android:layout_marginRight="@dimen/mpsdk_edittext_margin_inline_form"
             android:layout_marginTop="2dp"
             android:singleLine="true"
             android:imeOptions="actionNext"
@@ -149,8 +150,8 @@
             android:id="@+id/mpsdkCardSecurityCode"
             android:layout_width="@dimen/mpsdk_edittext_width_inline_form"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="15dp"
-            android:layout_marginRight="15dp"
+            android:layout_marginLeft="@dimen/mpsdk_edittext_margin_inline_form"
+            android:layout_marginRight="@dimen/mpsdk_edittext_margin_inline_form"
             android:layout_marginTop="2dp"
             android:singleLine="true"
             android:maxLength="4"
@@ -223,8 +224,8 @@
                         android:id="@+id/mpsdkCardIdentificationNumber"
                         android:layout_width="193dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginLeft="15dp"
-                        android:layout_marginRight="15dp"
+                        android:layout_marginLeft="@dimen/mpsdk_edittext_margin_inline_form"
+                        android:layout_marginRight="@dimen/mpsdk_edittext_margin_inline_form"
                         android:layout_marginTop="2dp"
                         android:imeOptions="actionNext"
                         android:singleLine="true"

--- a/sdk/src/main/res/values/dimens.xml
+++ b/sdk/src/main/res/values/dimens.xml
@@ -25,4 +25,8 @@
     <dimen name="mpsdk_shopping_cart_height">120dp</dimen>
     <dimen name="mpsdk_card_camera_distance">2560dp</dimen>
     <dimen name="mpsdk_edittext_width_inline_form">293dp</dimen>
+    <dimen name="mpsdk_edittext_min_width_inline_form">213dp</dimen>
+    <dimen name="mpsdk_edittext_margin_inline_form">15dp</dimen>
+    <dimen name="mpsdk_edittext_min_margin_inline_form">4dp</dimen>
+    <dimen name="mpsdk_edittext_margin_top_inline_form">2dp</dimen>
 </resources>

--- a/sdk/src/main/res/values/dimens.xml
+++ b/sdk/src/main/res/values/dimens.xml
@@ -24,4 +24,5 @@
     <dimen name="mpsdk_list_item_height_large">72dp</dimen>
     <dimen name="mpsdk_shopping_cart_height">120dp</dimen>
     <dimen name="mpsdk_card_camera_distance">2560dp</dimen>
+    <dimen name="mpsdk_edittext_width_inline_form">293dp</dimen>
 </resources>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -75,6 +75,9 @@
     <string name="mpsdk_cardholder_name_short">NOMBRE APELLIDO</string>
     <string name="mpsdk_title_activity_new_card">Ingresa los datos de tu tarjeta</string>
 
+    <string name="mpsdk_credit_card">Crédito</string>
+    <string name="mpsdk_debit_card">Débito</string>
+
     <!-- Congrats -->
     <string name="mpsdk_title_activity_congrat">¡Listo, se acreditó tu pago!</string>
     <string name="mpsdk_subtitle_action_activity_congrat">Te enviaremos los datos a\n%1$s</string>


### PR DESCRIPTION
## [WAIT for Q4] PaymentType Spinner

- Added spinner to choose a payment type in the guessing form, in the cases that the guessing itself can't resolve the payment method. This case mostly is useful for Mexico, in case someone is calling CardVaultActivity and enters a card that can be credit or debit type.
- [Video 1080 x 1920](https://drive.google.com/open?id=0B7v04H2J8VPCbDh6eG85enZ3Rnc)
- [Video 480 x 800](https://drive.google.com/open?id=0B7v04H2J8VPCQW9mWlg4ckJvTTg)

**Requirements**

- [ ] Coverage > 90%

_Note:_
Don´t know yet

- [ ] Android Lint check

_Note:_
Not yet

- [ ] Code Style checked

_Note:_
Not yet

If impacts documentation (new components, inputs or outputs?)
 - [ ] PR to develop-docs

_Note:_
Not yet