### PR TITLE
[Fix] Error message not being shown in security code activity

### DIFF
--- a/sdk/src/main/java/com/mercadopago/SecurityCodeActivity.java
+++ b/sdk/src/main/java/com/mercadopago/SecurityCodeActivity.java
@@ -21,6 +21,8 @@ import com.mercadopago.controllers.CheckoutTimer;
 import com.mercadopago.core.MercadoPagoCheckout;
 import com.mercadopago.customviews.MPEditText;
 import com.mercadopago.customviews.MPTextView;
+import com.mercadopago.exceptions.CardTokenException;
+import com.mercadopago.exceptions.ExceptionHandler;
 import com.mercadopago.exceptions.MercadoPagoError;
 import com.mercadopago.listeners.card.CardSecurityCodeTextWatcher;
 import com.mercadopago.model.ApiException;
@@ -415,11 +417,12 @@ public class SecurityCodeActivity extends MercadoPagoBaseActivity implements Sec
     }
 
     @Override
-    public void setErrorView(String message) {
+    public void setErrorView(CardTokenException exception) {
         mSecurityCodeEditText.toggleLineColorOnError(true);
         mButtonContainer.setVisibility(View.GONE);
         mErrorContainer.setVisibility(View.VISIBLE);
-        mErrorTextView.setText(message);
+        String errorText = ExceptionHandler.getErrorMessage(this, exception);
+        mErrorTextView.setText(errorText);
         setErrorState(ERROR_STATE);
     }
 

--- a/sdk/src/main/java/com/mercadopago/presenters/SecurityCodePresenter.java
+++ b/sdk/src/main/java/com/mercadopago/presenters/SecurityCodePresenter.java
@@ -175,8 +175,8 @@ public class SecurityCodePresenter extends MvpPresenter<SecurityCodeActivityView
             } else if (isSavedCardWithoutESC()) {
                 createTokenWithoutESC();
             }
-        } catch (CardTokenException e) {
-            getView().setErrorView(e.getMessage());
+        } catch (CardTokenException exception) {
+            getView().setErrorView(exception);
         }
     }
 
@@ -226,8 +226,8 @@ public class SecurityCodePresenter extends MvpPresenter<SecurityCodeActivityView
             }
             getView().clearErrorView();
             return true;
-        } catch (Exception e) {
-            getView().setErrorView(e.getMessage());
+        } catch (CardTokenException exception) {
+            getView().setErrorView(exception);
             return false;
         }
     }

--- a/sdk/src/main/java/com/mercadopago/providers/SecurityCodeProvider.java
+++ b/sdk/src/main/java/com/mercadopago/providers/SecurityCodeProvider.java
@@ -35,7 +35,7 @@ public interface SecurityCodeProvider extends ResourcesProvider {
 
     void validateSecurityCodeFromToken(String mSecurityCode, PaymentMethod mPaymentMethod, String firstSixDigits) throws CardTokenException;
 
-    void validateSecurityCodeFromToken(String mSecurityCode);
+    void validateSecurityCodeFromToken(String mSecurityCode) throws CardTokenException;
 
     void validateSecurityCodeFromToken(SavedCardToken savedCardToken, Card card) throws CardTokenException;
 

--- a/sdk/src/main/java/com/mercadopago/providers/SecurityCodeProviderImpl.java
+++ b/sdk/src/main/java/com/mercadopago/providers/SecurityCodeProviderImpl.java
@@ -151,8 +151,10 @@ public class SecurityCodeProviderImpl implements SecurityCodeProvider {
     }
 
     @Override
-    public void validateSecurityCodeFromToken(String securityCode) {
-        CardToken.validateSecurityCode(securityCode);
+    public void validateSecurityCodeFromToken(String securityCode) throws CardTokenException {
+        if (!CardToken.validateSecurityCode(securityCode)) {
+            throw new CardTokenException(CardTokenException.INVALID_FIELD);
+        }
     }
 
     @Override

--- a/sdk/src/main/java/com/mercadopago/views/SecurityCodeActivityView.java
+++ b/sdk/src/main/java/com/mercadopago/views/SecurityCodeActivityView.java
@@ -1,5 +1,6 @@
 package com.mercadopago.views;
 
+import com.mercadopago.exceptions.CardTokenException;
 import com.mercadopago.exceptions.MercadoPagoError;
 import com.mercadopago.model.ApiException;
 import com.mercadopago.mvp.MvpView;
@@ -13,7 +14,7 @@ public interface SecurityCodeActivityView extends MvpView {
 
     void showError(MercadoPagoError error, String requestOrigin);
 
-    void setErrorView(String message);
+    void setErrorView(CardTokenException exception);
 
     void clearErrorView();
 

--- a/sdk/src/test/java/com/mercadopago/securitycode/SecurityCodePresenterTest.java
+++ b/sdk/src/test/java/com/mercadopago/securitycode/SecurityCodePresenterTest.java
@@ -44,6 +44,7 @@ public class SecurityCodePresenterTest {
     private static final String CARD_AND_TOKEN_SET_WITHOUT_RECOVERY = "card_and_token_set_without_recovery";
     private static final String CARD_INFO_NOT_SET = "card_info_not_set";
     private static final String ERROR_SECURITY_CODE = "error_security_code";
+    private static final int CARD_TOKEN_INVALID_SECURITY_CODE = 9;
 
     @Test
     public void showErrorWhenInvalidParameters() {
@@ -293,7 +294,7 @@ public class SecurityCodePresenterTest {
         mvp.getPresenter().validateSecurityCodeInput();
 
         assertTrue(mvp.getView().errorState);
-        assertNotNull(mvp.getView().errorMessage);
+        assertNotNull(mvp.getView().cardTokenErrorCode);
     }
 
     @Test
@@ -627,7 +628,7 @@ public class SecurityCodePresenterTest {
         @Override
         public void validateSecurityCodeFromToken(String mSecurityCode, PaymentMethod mPaymentMethod, String firstSixDigits) throws CardTokenException {
             if (shouldFailSecurityCodeValidation) {
-                throw new RuntimeException("ERROR_SECURITY_CODE");
+                throw new CardTokenException(CARD_TOKEN_INVALID_SECURITY_CODE);
             }
         }
 
@@ -639,7 +640,7 @@ public class SecurityCodePresenterTest {
         @Override
         public void validateSecurityCodeFromToken(SavedCardToken savedCardToken, Card card) throws CardTokenException {
             if (shouldFailSecurityCodeValidation) {
-                throw new RuntimeException("ERROR_SECURITY_CODE");
+                throw new CardTokenException(CARD_TOKEN_INVALID_SECURITY_CODE);
             }
         }
 
@@ -659,6 +660,7 @@ public class SecurityCodePresenterTest {
         private boolean timerShown = false;
         private Integer maxLenght;
         private boolean errorState = false;
+        private Integer cardTokenErrorCode;
 
         @Override
         public void initialize() {
@@ -683,8 +685,8 @@ public class SecurityCodePresenterTest {
         }
 
         @Override
-        public void setErrorView(String message) {
-            this.errorMessage = message;
+        public void setErrorView(CardTokenException exception) {
+            this.cardTokenErrorCode = exception.getErrorCode();
             this.errorState = true;
         }
 


### PR DESCRIPTION
## [Fix] Error message not being shown in security code activity

- En la pantalla de código de seguridad no se estaba mostrando el mensaje de error cuando el usuario quiere continuar habiendo ingresado menos números de los necesarios.
- No se estaba usando el ExceptionHandler que se creó con el refactor a MVP de Guessing, que es quien toma la CardTokenException y la traduce a un mensaje de error.
- Ahora se reciben CardTokenExceptions siempre y se usa ese handler para mostrar los errores.