### PR TITLE
[Fix] Dependencies transitivity

### DIFF
--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -1,3 +1,9 @@
+## VERSION 3.7.1
+
+_09_11_2017_
+
+* Fix: Fixed dependencies transitivity
+
 ## VERSION 3.7.0
 
 _31_10_2017_

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The MercadoPago Android SDK makes it easy to collect your user's credit card det
 
 Add this line to your app's `build.gradle` inside the `dependencies` section:
 
-    compile 'com.mercadopago:sdk:3.7.0'
+    compile 'com.mercadopago:sdk:3.7.1'
 
 ### Eclipse
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -93,36 +93,36 @@ project.gradle.taskGraph.whenReady {
 
 dependencies {
 
-    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    compile fileTree(include: ['*.jar'], dir: 'libs')
 
-    androidTestImplementation "com.android.support.test.espresso:espresso-core:2.2.2"
-    androidTestImplementation "com.android.support.test.espresso:espresso-intents:2.2.2"
-    androidTestImplementation("com.android.support.test.espresso:espresso-contrib:2.2.2") {
+    androidTestCompile "com.android.support.test.espresso:espresso-core:2.2.2"
+    androidTestCompile "com.android.support.test.espresso:espresso-intents:2.2.2"
+    androidTestCompile("com.android.support.test.espresso:espresso-contrib:2.2.2") {
         exclude module: 'support-v4'
         exclude group: 'com.android.support', module: 'appcompat-v7'
         exclude group: 'com.android.support', module: 'design'
         exclude group: 'com.android.support', module: 'recyclerview-v7'
     }
 
-    testImplementation "junit:junit:$junit"
-    testImplementation "org.mockito:mockito-core:2.+"
+    testCompile "junit:junit:$junit"
+    testCompile "org.mockito:mockito-core:2.+"
 
-    implementation "com.android.support:cardview-v7:$support_library_version"
-    implementation "com.android.support:recyclerview-v7:$support_library_version"
-    implementation "com.android.support:support-v4:$support_library_version"
-    implementation "com.android.support:appcompat-v7:$support_library_version"
-    implementation "com.android.support:design:$support_library_version"
-    implementation "com.android.support:percent:$support_library_version"
-    implementation "com.android.support:support-annotations:$support_library_version"
+    compile "com.android.support:cardview-v7:$support_library_version"
+    compile "com.android.support:recyclerview-v7:$support_library_version"
+    compile "com.android.support:support-v4:$support_library_version"
+    compile "com.android.support:appcompat-v7:$support_library_version"
+    compile "com.android.support:design:$support_library_version"
+    compile "com.android.support:percent:$support_library_version"
+    compile "com.android.support:support-annotations:$support_library_version"
 
-    implementation "com.squareup.okhttp3:okhttp:$okhttp"
-    implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttp"
-    implementation "com.squareup.okhttp3:logging-interceptor:$okhttp"
-    implementation "com.squareup.retrofit2:retrofit:$retrofit"
-    implementation "com.squareup.retrofit2:converter-gson:$retrofit"
-    implementation "com.squareup.picasso:picasso:$picasso"
+    compile "com.squareup.okhttp3:okhttp:$okhttp"
+    compile "com.squareup.okhttp3:okhttp-urlconnection:$okhttp"
+    compile "com.squareup.okhttp3:logging-interceptor:$okhttp"
+    compile "com.squareup.retrofit2:retrofit:$retrofit"
+    compile "com.squareup.retrofit2:converter-gson:$retrofit"
+    compile "com.squareup.picasso:picasso:$picasso"
 
-    implementation project(':px-tracking')
+    compile project(':px-tracking')
 }
 
 configurations {


### PR DESCRIPTION
Se vuelve atrás el cambio del comando "implements" por "compile".
Se actualiza el README y el CHANGELOG-v3.