### PR TITLE
[Fix] Recovering payment on card disabled

### DIFF
--- a/sdk/src/main/java/com/mercadopago/model/PaymentRecovery.java
+++ b/sdk/src/main/java/com/mercadopago/model/PaymentRecovery.java
@@ -74,17 +74,23 @@ public class PaymentRecovery {
                 Payment.StatusCodes.STATUS_DETAIL_CC_REJECTED_BAD_FILLED_SECURITY_CODE.equals(statusDetail) ||
                 Payment.StatusCodes.STATUS_DETAIL_CC_REJECTED_BAD_FILLED_DATE.equals(statusDetail) ||
                 Payment.StatusCodes.STATUS_DETAIL_CC_REJECTED_CALL_FOR_AUTHORIZE.equals(statusDetail) ||
-                Payment.StatusCodes.STATUS_DETAIL_INVALID_ESC.equals(statusDetail);
+                Payment.StatusCodes.STATUS_DETAIL_INVALID_ESC.equals(statusDetail) ||
+                Payment.StatusCodes.STATUS_DETAIL_CC_REJECTED_CARD_DISABLED.equals(statusDetail);
     }
 
     private Boolean isStatusDetailRecoverable(String statusDetail) {
         return statusDetail != null &&
                 (Payment.StatusCodes.STATUS_DETAIL_CC_REJECTED_CALL_FOR_AUTHORIZE.equals(statusDetail) ||
-                        Payment.StatusCodes.STATUS_DETAIL_INVALID_ESC.equals(statusDetail));
+                        Payment.StatusCodes.STATUS_DETAIL_INVALID_ESC.equals(statusDetail) ||
+                        Payment.StatusCodes.STATUS_DETAIL_CC_REJECTED_CARD_DISABLED.equals(statusDetail));
     }
 
     public boolean isStatusDetailCallForAuthorize() {
         return mStatusDetail != null && Payment.StatusCodes.STATUS_DETAIL_CC_REJECTED_CALL_FOR_AUTHORIZE.equals(mStatusDetail);
+    }
+
+    public boolean isStatusDetailCardDisabled() {
+        return mStatusDetail != null && Payment.StatusCodes.STATUS_DETAIL_CC_REJECTED_CARD_DISABLED.equals(mStatusDetail);
     }
 
     public boolean isStatusDetailInvalidESC() {

--- a/sdk/src/main/java/com/mercadopago/presenters/SecurityCodePresenter.java
+++ b/sdk/src/main/java/com/mercadopago/presenters/SecurityCodePresenter.java
@@ -200,7 +200,8 @@ public class SecurityCodePresenter extends MvpPresenter<SecurityCodeActivityView
     }
 
     private boolean hasToCloneToken() {
-        return mPaymentRecovery != null && mPaymentRecovery.isStatusDetailCallForAuthorize() && mToken != null;
+        return mPaymentRecovery != null && (mPaymentRecovery.isStatusDetailCallForAuthorize() ||
+                mPaymentRecovery.isStatusDetailCardDisabled()) && mToken != null;
     }
 
     private boolean hasToRecoverTokenFromESC() {


### PR DESCRIPTION
# [Fix] Recovering payment on card disabled

- En el caso de Rejected por "card disabled", el botón del footer de "Ya habilité mi tarjeta" estaba tirando un error al tocarlo.
- Se implementó que este botón recupere el pago clonando el token (caso de uso que antes no se hacía con ese status detail)