### PR TITLE
[Fix] Showed payment id with plugin

### DIFF
--- a/sdk/src/main/java/com/mercadopago/paymentresult/components/Body.java
+++ b/sdk/src/main/java/com/mercadopago/paymentresult/components/Body.java
@@ -126,7 +126,7 @@ public class Body extends Component<PaymentResultBodyProps, Void> {
     public boolean hasReceipt() {
         final com.mercadopago.model.PaymentMethod paymentMethod = props.paymentData.getPaymentMethod();
         return props.paymentId != null && props.isReceiptEnabled() && props.paymentData != null
-                && isStatusApproved() && !isPluginType(paymentMethod) && isPaymentTypeOn(paymentMethod);
+                && isStatusApproved() && isPaymentTypeOn(paymentMethod);
     }
 
     public Receipt getReceiptComponent() {
@@ -154,8 +154,8 @@ public class Body extends Component<PaymentResultBodyProps, Void> {
         final CheckoutStore store = CheckoutStore.getInstance();
         final CustomComponent.Props props =
                 new CustomComponent.Props(
-                    store.getData(),
-                    store.getCheckoutPreference()
+                        store.getData(),
+                        store.getCheckoutPreference()
                 );
         return store.getPaymentResultScreenPreference()
                 .getApprovedTopCustomComponentFactory()


### PR DESCRIPTION
Se muestra el payment_id cuando se paga con plugin. 

**Antes:**
![screen shot 2018-01-26 at 4 43 57 pm](https://user-images.githubusercontent.com/4195740/35458054-a979aa46-02b9-11e8-84a3-8ae12ded3011.png)

**Después:**
![screen shot 2018-01-26 at 4 43 02 pm](https://user-images.githubusercontent.com/4195740/35458055-a9a308f0-02b9-11e8-856c-d766b25dd6aa.png)