### PR TITLE
Use NoOpStrategy

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -129,7 +129,7 @@ dependencies {
 
     compile "com.google.code.gson:gson:$gson"
     compile "com.squareup.picasso:picasso:$picasso"
-    compile 'com.mercadopago:tracking:3.0.2'
+    compile 'com.mercadopago:tracking:3.0.2-noop-1'
 }
 configurations {
     archives {

--- a/sdk/src/main/java/com/mercadopago/BankDealsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/BankDealsActivity.java
@@ -58,7 +58,6 @@ public class BankDealsActivity extends MercadoPagoActivity {
     protected void trackInitialScreen() {
         MPTrackingContext mpTrackingContext = new MPTrackingContext.Builder(this, mMerchantPublicKey)
                 .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                 .build();
         ScreenViewEvent event = new ScreenViewEvent.Builder()
                 .setFlowId(FlowHandler.getInstance().getFlowId())

--- a/sdk/src/main/java/com/mercadopago/CallForAuthorizeActivity.java
+++ b/sdk/src/main/java/com/mercadopago/CallForAuthorizeActivity.java
@@ -162,7 +162,6 @@ public class CallForAuthorizeActivity extends MercadoPagoBaseActivity implements
     protected void trackScreen() {
         MPTrackingContext mpTrackingContext = new MPTrackingContext.Builder(this, mMerchantPublicKey)
                 .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                 .build();
 
         ScreenViewEvent.Builder builder = new ScreenViewEvent.Builder()

--- a/sdk/src/main/java/com/mercadopago/CongratsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/CongratsActivity.java
@@ -243,7 +243,6 @@ public class CongratsActivity extends MercadoPagoBaseActivity implements ReviewS
     protected void trackScreen() {
         final MPTrackingContext mpTrackingContext = new MPTrackingContext.Builder(this, mMerchantPublicKey)
                 .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                 .build();
 
         final ScreenViewEvent.Builder builder = new ScreenViewEvent.Builder()

--- a/sdk/src/main/java/com/mercadopago/ErrorActivity.java
+++ b/sdk/src/main/java/com/mercadopago/ErrorActivity.java
@@ -63,7 +63,6 @@ public class ErrorActivity extends MercadoPagoBaseActivity {
     private void trackScreen() {
         MPTrackingContext mpTrackingContext = new MPTrackingContext.Builder(this, mPublicKey)
                 .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                 .build();
 
         ScreenViewEvent.Builder builder = new ScreenViewEvent.Builder()

--- a/sdk/src/main/java/com/mercadopago/InstallmentsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/InstallmentsActivity.java
@@ -238,7 +238,6 @@ public class InstallmentsActivity extends MercadoPagoBaseActivity implements Ins
     protected void trackScreen() {
         MPTrackingContext mTrackingContext = new MPTrackingContext.Builder(this, mPublicKey)
                 .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                 .build();
 
         ScreenViewEvent event = new ScreenViewEvent.Builder()

--- a/sdk/src/main/java/com/mercadopago/InstructionsActivity.java
+++ b/sdk/src/main/java/com/mercadopago/InstructionsActivity.java
@@ -204,7 +204,6 @@ public class InstructionsActivity extends MercadoPagoBaseActivity {
     protected void trackScreen() {
         MPTrackingContext mpTrackingContext = new MPTrackingContext.Builder(this, mMerchantPublicKey)
                 .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                 .build();
 
 

--- a/sdk/src/main/java/com/mercadopago/IssuersActivity.java
+++ b/sdk/src/main/java/com/mercadopago/IssuersActivity.java
@@ -187,7 +187,6 @@ public class IssuersActivity extends MercadoPagoBaseActivity implements IssuersA
     protected void trackScreen() {
         MPTrackingContext mpTrackingContext = new MPTrackingContext.Builder(this, mPublicKey)
                 .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                 .build();
 
         ScreenViewEvent event = new ScreenViewEvent.Builder()

--- a/sdk/src/main/java/com/mercadopago/PaymentTypesActivity.java
+++ b/sdk/src/main/java/com/mercadopago/PaymentTypesActivity.java
@@ -140,7 +140,6 @@ public class PaymentTypesActivity extends MercadoPagoBaseActivity implements Pay
     protected void trackScreen() {
         MPTrackingContext mpTrackingContext = new MPTrackingContext.Builder(this, mPresenter.getPublicKey())
                 .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                 .build();
 
         ScreenViewEvent event = new ScreenViewEvent.Builder()

--- a/sdk/src/main/java/com/mercadopago/PaymentVaultActivity.java
+++ b/sdk/src/main/java/com/mercadopago/PaymentVaultActivity.java
@@ -239,7 +239,6 @@ public class PaymentVaultActivity extends MercadoPagoBaseActivity implements Pay
     public void trackInitialScreen() {
         MPTrackingContext mpTrackingContext = new MPTrackingContext.Builder(this, mPublicKey)
                 .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                 .build();
         ScreenViewEvent event = new ScreenViewEvent.Builder()
                 .setFlowId(FlowHandler.getInstance().getFlowId())
@@ -257,7 +256,6 @@ public class PaymentVaultActivity extends MercadoPagoBaseActivity implements Pay
 
             MPTrackingContext mpTrackingContext = new MPTrackingContext.Builder(this, mPublicKey)
                     .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                    .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                     .build();
 
             ScreenViewEvent event = null;

--- a/sdk/src/main/java/com/mercadopago/PendingActivity.java
+++ b/sdk/src/main/java/com/mercadopago/PendingActivity.java
@@ -155,7 +155,6 @@ public class PendingActivity extends MercadoPagoBaseActivity implements TimerObs
     protected void trackScreen() {
         MPTrackingContext mpTrackingContext = new MPTrackingContext.Builder(this, mMerchantPublicKey)
                 .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                 .build();
 
 

--- a/sdk/src/main/java/com/mercadopago/RejectionActivity.java
+++ b/sdk/src/main/java/com/mercadopago/RejectionActivity.java
@@ -164,7 +164,6 @@ public class RejectionActivity extends MercadoPagoBaseActivity implements TimerO
     protected void trackScreen() {
         MPTrackingContext mpTrackingContext = new MPTrackingContext.Builder(this, mMerchantPublicKey)
                 .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                 .build();
 
 

--- a/sdk/src/main/java/com/mercadopago/ReviewAndConfirmActivity.java
+++ b/sdk/src/main/java/com/mercadopago/ReviewAndConfirmActivity.java
@@ -262,7 +262,6 @@ public class ReviewAndConfirmActivity extends MercadoPagoBaseActivity implements
     public void trackScreen() {
         MPTrackingContext mpTrackingContext = new MPTrackingContext.Builder(this, mPublicKey)
                 .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                 .build();
 
         PaymentData paymentData = mPresenter.getPaymentData();

--- a/sdk/src/main/java/com/mercadopago/SecurityCodeActivity.java
+++ b/sdk/src/main/java/com/mercadopago/SecurityCodeActivity.java
@@ -289,7 +289,6 @@ public class SecurityCodeActivity extends MercadoPagoBaseActivity implements Sec
     public void trackScreen() {
         MPTrackingContext mpTrackingContext = new MPTrackingContext.Builder(this, mMerchantPublicKey)
                 .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                 .build();
 
         ScreenViewEvent event = new ScreenViewEvent.Builder()

--- a/sdk/src/main/java/com/mercadopago/paymentresult/PaymentResultActivity.java
+++ b/sdk/src/main/java/com/mercadopago/paymentresult/PaymentResultActivity.java
@@ -312,7 +312,6 @@ public class PaymentResultActivity extends AppCompatActivity implements PaymentR
     public void trackScreen(ScreenViewEvent event) {
         MPTrackingContext mpTrackingContext = new MPTrackingContext.Builder(this, merchantPublicKey)
                 .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                .setTrackingStrategy(TrackingUtil.FORCED_STRATEGY)
                 .build();
 
         mpTrackingContext.trackEvent(event);

--- a/sdk/src/main/java/com/mercadopago/providers/GuessingCardProviderImpl.java
+++ b/sdk/src/main/java/com/mercadopago/providers/GuessingCardProviderImpl.java
@@ -52,7 +52,6 @@ public class GuessingCardProviderImpl implements GuessingCardProvider {
         if (trackingContext == null) {
             trackingContext = new MPTrackingContext.Builder(context, publicKey)
                     .setCheckoutVersion(BuildConfig.VERSION_NAME)
-                    .setTrackingStrategy(TrackingUtil.BATCH_STRATEGY)
                     .build();
         }
         return trackingContext;

--- a/sdk/src/main/java/com/mercadopago/tracker/MPTrackingContext.java
+++ b/sdk/src/main/java/com/mercadopago/tracker/MPTrackingContext.java
@@ -8,6 +8,7 @@ import com.mercadopago.model.Fingerprint;
 import com.mercadopago.tracking.model.AppInformation;
 import com.mercadopago.tracking.model.DeviceInfo;
 import com.mercadopago.tracking.model.Event;
+import com.mercadopago.tracking.tracker.MPTracker;
 
 /**
  * Created by vaserber on 6/5/17.
@@ -51,12 +52,12 @@ public class MPTrackingContext {
                 .build();
     }
 
-    public void trackEvent(final Event event) {
-        // No tracking
+    public void trackEvent(Event event) {
+        MPTracker.getInstance().trackEvent(publicKey, appInformation, deviceInfo, event, context, trackingStrategy);
     }
 
     public void clearExpiredTracks() {
-        // No tracking
+        MPTracker.getInstance().clearExpiredTracks();
     }
 
     public static class Builder {


### PR DESCRIPTION
//Description
Usamos NoOpStrategy para que px no trackee internamente, si se llaman a los listeners.

//Issue related

Closes #


**Requirements**

- [ ] Coverage > 90%

_Note:_


- [ ] Android Lint check

_Note:_


- [ ] Code Style checked

_Note:_

- [ ] Tested with "Don't keep Activities" configuration.

_Note:_


If impacts documentation (new components, inputs or outputs?)
 - [ ] PR to develop-docs

_Note:_
