### PR TITLE
[Feature] Payment Method Plugin ScreenTracking

### DIFF
--- a/sdk/src/main/java/com/mercadopago/PaymentVaultActivity.java
+++ b/sdk/src/main/java/com/mercadopago/PaymentVaultActivity.java
@@ -422,7 +422,7 @@ public class PaymentVaultActivity extends MercadoPagoBaseActivity implements Pay
 
         if (plugin != null && plugin.isEnabled(store.getData()) && plugin.isConfigurationComponentEnabled(store.getData())) {
 
-            startActivityForResult(PaymentMethodPluginActivity.getIntent(PaymentVaultActivity.this), MercadoPagoComponents.Activities.PLUGIN_PAYMENT_METHOD_REQUEST_CODE);
+            startActivityForResult(PaymentMethodPluginActivity.getIntent(PaymentVaultActivity.this, mPublicKey), MercadoPagoComponents.Activities.PLUGIN_PAYMENT_METHOD_REQUEST_CODE);
             overrideTransitionIn();
 
         } else {
@@ -624,7 +624,7 @@ public class PaymentVaultActivity extends MercadoPagoBaseActivity implements Pay
     }
 
     private boolean shouldFinishOnBack(Intent data) {
-        return  !CheckoutStore.getInstance().hasEnabledPaymenthMethodPlugin() && (mPaymentVaultPresenter.getSelectedSearchItem() != null && (!mPaymentVaultPresenter.getSelectedSearchItem().hasChildren()
+        return !CheckoutStore.getInstance().hasEnabledPaymenthMethodPlugin() && (mPaymentVaultPresenter.getSelectedSearchItem() != null && (!mPaymentVaultPresenter.getSelectedSearchItem().hasChildren()
                 || (mPaymentVaultPresenter.getSelectedSearchItem().getChildren().size() == 1))
                 || (mPaymentVaultPresenter.getSelectedSearchItem() == null && mPaymentVaultPresenter.isOnlyOneItemAvailable())
                 || (data != null) && (data.getStringExtra("mercadoPagoError") != null));

--- a/sdk/src/main/java/com/mercadopago/plugins/PaymentMethodPluginActivity.java
+++ b/sdk/src/main/java/com/mercadopago/plugins/PaymentMethodPluginActivity.java
@@ -7,6 +7,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
+import com.mercadopago.BuildConfig;
 import com.mercadopago.components.Action;
 import com.mercadopago.components.ActionDispatcher;
 import com.mercadopago.components.BackAction;
@@ -15,6 +16,10 @@ import com.mercadopago.components.ComponentManager;
 import com.mercadopago.components.NextAction;
 import com.mercadopago.core.CheckoutStore;
 import com.mercadopago.plugins.model.PaymentMethodInfo;
+import com.mercadopago.tracker.FlowHandler;
+import com.mercadopago.tracker.MPTrackingContext;
+import com.mercadopago.tracking.model.ScreenViewEvent;
+import com.mercadopago.tracking.utils.TrackingUtil;
 
 /**
  * Created by nfortuna on 12/13/17.
@@ -22,8 +27,15 @@ import com.mercadopago.plugins.model.PaymentMethodInfo;
 
 public class PaymentMethodPluginActivity extends AppCompatActivity implements ActionDispatcher {
 
-    public static Intent getIntent(@NonNull final Context context) {
-        return new Intent(context, PaymentMethodPluginActivity.class);
+    private static final String SCREEN_NAME_CONFIG_PAYMENT_METHOD_PLUGIN = "CONFIG_PAYMENT_METHOD";
+    private static final String PUBLIC_KEY = "public_key";
+
+    private String mPublicKey;
+
+    public static Intent getIntent(@NonNull final Context context, @NonNull final String publicKey) {
+        Intent intent = new Intent(context, PaymentMethodPluginActivity.class);
+        intent.putExtra(PUBLIC_KEY, publicKey);
+        return intent;
     }
 
     private ComponentManager componentManager;
@@ -36,6 +48,11 @@ public class PaymentMethodPluginActivity extends AppCompatActivity implements Ac
                 CheckoutStore.getInstance().getSelectedPaymentMethodInfo(this);
         final PaymentMethodPlugin plugin = CheckoutStore
                 .getInstance().getPaymentMethodPluginById(paymentMethodInfo.id);
+
+        Intent intent = getIntent();
+        mPublicKey = intent.getStringExtra(PUBLIC_KEY);
+
+        trackScreen(plugin.getId());
 
         if (plugin == null) {
             setResult(RESULT_CANCELED);
@@ -59,6 +76,23 @@ public class PaymentMethodPluginActivity extends AppCompatActivity implements Ac
 
         component.setDispatcher(this);
         componentManager.render(component);
+    }
+
+    private void trackScreen(String id) {
+
+        String screenName = SCREEN_NAME_CONFIG_PAYMENT_METHOD_PLUGIN + "_" + id;
+
+        MPTrackingContext mTrackingContext = new MPTrackingContext.Builder(this, mPublicKey)
+                .setCheckoutVersion(BuildConfig.VERSION_NAME)
+                .build();
+
+        ScreenViewEvent event = new ScreenViewEvent.Builder()
+                .setFlowId(FlowHandler.getInstance().getFlowId())
+                .setScreenId(screenName)
+                .setScreenName(screenName)
+                .build();
+
+        mTrackingContext.trackEvent(event);
     }
 
     @Override


### PR DESCRIPTION
# Descripción
Se agrega por pedido de InStore el trackeo de la pantalla de plugin. Se acordó hacerlo con el String CONFIG_PAYMENT_METHOD + id_plugin que setean ellos. 

# Cómo probar
Se puede configurar un TrackListener en CheckoutExampleActivity con un log del nombre de pantalla. Al elegir un plugin como medio de pago (como dinero en cuenta) Se debería loguear como screenName "CONFIG_PAYMENT_METHOD" + id_plugin. 

```
MPTracker.getInstance().setTracksListener(new TracksListener() {
            @Override
            public void onScreenLaunched(String screenName) {
                Log.v("SCREEN_NAME_TRACKED",screenName);
            }

            @Override
            public void onEventPerformed(Map<String, String> event) {

            }
        });
```