### PR TITLE
Tracking lib update version 3.0.2-noop-2

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -126,11 +126,12 @@ dependencies {
 
     compile ("com.mercadopago:services:1.0.1") {
         exclude group: "com.google.code.gson", module: "gson"
+        exclude group: "com.mercadopago", module: "tracking"
     }
 
     compile "com.google.code.gson:gson:$gson"
     compile "com.squareup.picasso:picasso:$picasso"
-    compile 'com.mercadopago:tracking:3.0.2-noop-1'
+    compile 'com.mercadopago:tracking:3.0.2-noop-2'
 }
 configurations {
     archives {


### PR DESCRIPTION
//Description

Se actualizó la librería de tracking a la version 3.0.2-noop-2

//Issue related

Closes #


**Requirements**

- [ ] Coverage > 90%

_Note:_


- [ ] Android Lint check

_Note:_


- [ ] Code Style checked

_Note:_

- [ ] Tested with "Don't keep Activities" configuration.

_Note:_


If impacts documentation (new components, inputs or outputs?)
 - [ ] PR to develop-docs

_Note:_
