### PR TITLE
[Fix] Null view reference

### DIFF
--- a/example/src/main/java/com/mercadopago/examples/checkout/CheckoutExampleActivity.java
+++ b/example/src/main/java/com/mercadopago/examples/checkout/CheckoutExampleActivity.java
@@ -116,7 +116,7 @@ public class CheckoutExampleActivity extends AppCompatActivity {
     }
 
     private CheckoutPreference getCheckoutPreference() {
-        return new CheckoutPreference("243962506-0b4a9ec4-34b3-4acc-b25c-5188c027eea5");
+        return new CheckoutPreference(mCheckoutPreferenceId);
     }
 
     @Override

--- a/example/src/main/java/com/mercadopago/examples/checkout/CheckoutExampleActivity.java
+++ b/example/src/main/java/com/mercadopago/examples/checkout/CheckoutExampleActivity.java
@@ -116,7 +116,7 @@ public class CheckoutExampleActivity extends AppCompatActivity {
     }
 
     private CheckoutPreference getCheckoutPreference() {
-        return new CheckoutPreference(mCheckoutPreferenceId);
+        return new CheckoutPreference("243962506-0b4a9ec4-34b3-4acc-b25c-5188c027eea5");
     }
 
     @Override

--- a/sdk/src/main/java/com/mercadopago/uicontrollers/reviewandconfirm/ReviewProductView.java
+++ b/sdk/src/main/java/com/mercadopago/uicontrollers/reviewandconfirm/ReviewProductView.java
@@ -32,7 +32,6 @@ public class ReviewProductView implements ReviewProductViewController {
     protected MPTextView mProductDescription;
     protected MPTextView mProductQuantity;
     protected MPTextView mProductPrice;
-    protected View mFirstSeparator;
 
     private Context mContext;
     private ReviewScreenPreference mReviewScreenPreference;
@@ -55,7 +54,6 @@ public class ReviewProductView implements ReviewProductViewController {
         mProductDescription = (MPTextView) mView.findViewById(R.id.mpsdkAdapterReviewProductDescription);
         mProductQuantity = (MPTextView) mView.findViewById(R.id.mpsdkAdapterReviewProductQuantity);
         mProductPrice = (MPTextView) mView.findViewById(R.id.mpsdkAdapterReviewProductPrice);
-        mFirstSeparator = mView.findViewById(R.id.mpsdkFirstSeparator);
     }
 
     @Override
@@ -65,9 +63,6 @@ public class ReviewProductView implements ReviewProductViewController {
 
     @Override
     public void drawProduct(int position, Item item, String currencyId) {
-        if (position != 0) {
-            mFirstSeparator.setVisibility(View.GONE);
-        }
         String pictureUrl = item.getPictureUrl();
 
         setProductIcon(pictureUrl);


### PR DESCRIPTION
//Description

A separator view was removed from xml layout but had a reference in code, in a particular situation produces NPE.

//Issue related

Closes #


**Requirements**

- [ ] Coverage > 90%

_Note:_


- [ ] Android Lint check

_Note:_


- [ ] Code Style checked

_Note:_

- [ ] Tested with "Don't keep Activities" configuration.

_Note:_


If impacts documentation (new components, inputs or outputs?)
 - [ ] PR to develop-docs

_Note:_
