### PR TITLE
[Fix] changed text dimens from dp to sp

### DIFF
--- a/sdk/src/main/res/values/dimens.xml
+++ b/sdk/src/main/res/values/dimens.xml
@@ -3,16 +3,7 @@
     <dimen name="mpsdk_activity_vertical_margin">16dp</dimen>
     <dimen name="mpsdk_padding_hlf">5dp</dimen>
     <dimen name="mpsdk_padding_std">10dp</dimen>
-    <dimen name="mpsdk_regular_text">16dp</dimen>
-    <dimen name="mpsdk_small_text">14dp</dimen>
-    <dimen name="mpsdk_smaller_text">12dp</dimen>
-    <dimen name="mpsdk_smallest_text">8dp</dimen>
-    <dimen name="mpsdk_title_text">20dp</dimen>
-    <dimen name="mpsdk_large_text">22dp</dimen>
     <dimen name="mpsdk_box_default_stroke">1dp</dimen>
-    <dimen name="mpsdk_big_text">22dp</dimen>
-    <dimen name="mpsdk_medium_smaller_text">15dp</dimen>
-    <dimen name="mpsdk_medium_text">16dp</dimen>
     <dimen name="mpsdk_margin_std">10dp</dimen>
     <dimen name="mpsdk_button_height">55dp</dimen>
     <dimen name="mpsdk_card_corner_radius">0dp</dimen>
@@ -36,10 +27,6 @@
     <dimen name="mpsdk_card_size_big_shadow_width">146dp</dimen>
     <dimen name="mpsdk_card_size_medium_height_no_border">141dp</dimen>
     <dimen name="mpsdk_list_row_height">82dp</dimen>
-    <dimen name="mpsdk_payer_cost_small_text">20dp</dimen>
-    <dimen name="mpsdk_payer_cost_total_small_text">14dp</dimen>
-    <dimen name="mpsdk_payment_text_small_text">20dp</dimen>
-    <dimen name="mpsdk_payment_description_small_text">14dp</dimen>
 
     <!-- Spinner -->
     <dimen name="mpsdk_progress_stroke">3dp</dimen>
@@ -80,14 +67,28 @@
     <dimen name="mpsdk_zero_height">0dp</dimen>
 
     <!-- Text -->
-    <dimen name="mpsdk_xxxl_text">26dp</dimen>
-    <dimen name="mpsdk_xxl_text">24dp</dimen>
-    <dimen name="mpsdk_xl_text">22dp</dimen>
-    <dimen name="mpsdk_l_text">20dp</dimen>
-    <dimen name="mpsdk_m_text">18dp</dimen>
-    <dimen name="mpsdk_s_text">16dp</dimen>
-    <dimen name="mpsdk_xs_text">14dp</dimen>
-    <dimen name="mpsdk_xxs_text">12dp</dimen>
+    <dimen name="mpsdk_xxxl_text">26sp</dimen>
+    <dimen name="mpsdk_xxl_text">24sp</dimen>
+    <dimen name="mpsdk_xl_text">22sp</dimen>
+    <dimen name="mpsdk_l_text">20sp</dimen>
+    <dimen name="mpsdk_m_text">18sp</dimen>
+    <dimen name="mpsdk_s_text">16sp</dimen>
+    <dimen name="mpsdk_xs_text">14sp</dimen>
+    <dimen name="mpsdk_xxs_text">12sp</dimen>
+    <dimen name="mpsdk_regular_text">16sp</dimen>
+    <dimen name="mpsdk_small_text">14sp</dimen>
+    <dimen name="mpsdk_smaller_text">12sp</dimen>
+    <dimen name="mpsdk_smallest_text">8sp</dimen>
+    <dimen name="mpsdk_title_text">20sp</dimen>
+    <dimen name="mpsdk_large_text">22sp</dimen>
+    <dimen name="mpsdk_big_text">22sp</dimen>
+    <dimen name="mpsdk_medium_smaller_text">15sp</dimen>
+    <dimen name="mpsdk_medium_text">16sp</dimen>
+    <dimen name="mpsdk_payer_cost_small_text">20sp</dimen>
+    <dimen name="mpsdk_payer_cost_total_small_text">14sp</dimen>
+    <dimen name="mpsdk_payment_text_small_text">20sp</dimen>
+    <dimen name="mpsdk_payment_description_small_text">14sp</dimen>
+
 
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>


### PR DESCRIPTION
- changed dp sizes to dp sizes is well known the existence of redundant dimensions but due business rules is supposed to keep separated