### PR TITLE
[Hotfix] inconsistencia de lenguaje

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,6 @@ retrofit=2.4.0
 picasso=2.5.2
 junit=4.12
 leak_cannary=1.5.4
-version_to_deploy=4.0.0-beta-34.0.2
+version_to_deploy=4.0.0-beta-34.0.3
 meli_ui_lib=5.2.0
 multidex=1.0.3

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/di/ApplicationModule.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/di/ApplicationModule.java
@@ -2,6 +2,9 @@ package com.mercadopago.android.px.internal.di;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.os.Build;
+import android.os.LocaleList;
 import android.support.annotation.NonNull;
 import com.mercadopago.android.px.internal.datasource.cache.FileManager;
 import com.mercadopago.android.px.util.JsonUtil;
@@ -46,6 +49,18 @@ class ApplicationModule implements PreferenceComponent {
     }
 
     /* default */ String getLanguage() {
-        return context.getResources().getConfiguration().locale.getLanguage();
+
+        final Configuration configuration = context.getResources().getConfiguration();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            final LocaleList locales = configuration.getLocales();
+            if (!locales.isEmpty()) {
+                return locales.get(0).getLanguage();
+            } else {
+                return configuration.locale.getLanguage();
+            }
+        } else {
+            return configuration.locale.getLanguage();
+        }
     }
 }

--- a/px-services/src/main/java/com/mercadopago/android/px/services/core/MercadoPagoServices.java
+++ b/px-services/src/main/java/com/mercadopago/android/px/services/core/MercadoPagoServices.java
@@ -2,6 +2,9 @@ package com.mercadopago.android.px.services.core;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.res.Configuration;
+import android.os.Build;
+import android.os.LocaleList;
 import android.support.annotation.NonNull;
 import com.mercadopago.android.px.model.BankDeal;
 import com.mercadopago.android.px.model.CardToken;
@@ -165,7 +168,7 @@ public class MercadoPagoServices {
 
     public void getBankDeals(final Callback<List<BankDeal>> callback) {
         BankDealService service = getDefaultRetrofit(mContext).create(BankDealService.class);
-        service.getBankDeals(this.mPublicKey, mPrivateKey, mContext.getResources().getConfiguration().locale.toString())
+        service.getBankDeals(this.mPublicKey, mPrivateKey, getLocale())
             .enqueue(callback);
     }
 
@@ -179,7 +182,23 @@ public class MercadoPagoServices {
         PaymentService service = getDefaultRetrofit(mContext).create(PaymentService.class);
         service.getInstallments(Settings.servicesVersion, this.mPublicKey, mPrivateKey, bin, amount, issuerId,
             paymentMethodId,
-            mContext.getResources().getConfiguration().locale.toString(), mProcessingMode).enqueue(callback);
+            getLocale(), mProcessingMode).enqueue(callback);
+    }
+
+    private String getLocale() {
+
+        final Configuration configuration = mContext.getResources().getConfiguration();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            final LocaleList locales = configuration.getLocales();
+            if (!locales.isEmpty()) {
+                return locales.get(0).getLanguage();
+            } else {
+                return configuration.locale.getLanguage();
+            }
+        } else {
+            return configuration.locale.getLanguage();
+        }
     }
 
     public void getIssuers(String paymentMethodId, String bin, final Callback<List<Issuer>> callback) {


### PR DESCRIPTION
Versiones de API > 24 no muestran correctamente el lenguaje localizado para textos provenientes de la red.
## Cómo probarlo
Configurar dispositivo en otro idioma usando el SDK de desarrollo de meli, estando en un site determinado.