### PR TITLE
[hotfix] 4.0.0 beta 34.0.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,6 @@ retrofit=2.4.0
 picasso=2.5.2
 junit=4.12
 leak_cannary=1.5.4
-version_to_deploy=4.0.0-beta-34.0.6
+version_to_deploy=4.0.0-beta-34.0.7
 meli_ui_lib=5.+
 multidex=1.0.3

--- a/px-checkout/src/main/res/values-es-rAR/strings.xml
+++ b/px-checkout/src/main/res/values-es-rAR/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="px_homebanking">Home Banking de</string>
+    <string name="px_card_installments_title">¿En cuántas cuotas?</string>
+    <string name="px_error_message_invalid_installments">Número de cuotas inválido</string>
+</resources>


### PR DESCRIPTION

## Motivación y Contexto
Api >=27 cambia la forma de resolver resources por región, generando que en apps es-rAR se observen textos en es-rMX

## Cómo probarlo
device Api >=27 - > forzar locale a es AR; entrar al checkout e ir a installments, debe decir cuotas y no mensualidades.