### PR TITLE
[Fix] Fixed recovery payment case with exploding button in one tap

### DIFF
--- a/CHANGELOG-v4.md
+++ b/CHANGELOG-v4.md
@@ -1,5 +1,9 @@
 ## VERSION 4.0.2
 
+_05_09_2018_
+
+* Fix: one tap with payment recovery
+
 ## VERSION 4.0.1
 
 _03_09_2018_

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/onetap/OneTapFragment.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/onetap/OneTapFragment.java
@@ -7,6 +7,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
@@ -28,6 +29,7 @@ import com.mercadopago.android.px.internal.repository.PaymentSettingRepository;
 import com.mercadopago.android.px.internal.tracker.FlowHandler;
 import com.mercadopago.android.px.internal.tracker.MPTrackingContext;
 import com.mercadopago.android.px.internal.tracker.Tracker;
+import com.mercadopago.android.px.internal.util.StatusBarDecorator;
 import com.mercadopago.android.px.internal.viewmodel.OneTapModel;
 import com.mercadopago.android.px.model.BusinessPayment;
 import com.mercadopago.android.px.model.Card;
@@ -53,6 +55,7 @@ public class OneTapFragment extends Fragment implements OneTap.View {
     private ExplodingFragment explodingFragment;
     private Toolbar toolbar;
     private OneTapView oneTapView;
+    private boolean explodingProcess;
 
     public static OneTapFragment getInstance(@NonNull final OneTapModel oneTapModel) {
         final OneTapFragment oneTapFragment = new OneTapFragment();
@@ -74,6 +77,9 @@ public class OneTapFragment extends Fragment implements OneTap.View {
         super.onResume();
         final OneTapModel model = (OneTapModel) getArguments().getSerializable(ARG_ONE_TAP_MODEL);
         presenter.onViewResumed(model);
+        if (explodingFragment != null && explodingFragment.isAdded() && !explodingProcess) {
+            cancelLoading();
+        }
     }
 
     @Override
@@ -219,6 +225,7 @@ public class OneTapFragment extends Fragment implements OneTap.View {
 
     @Override
     public void showPaymentResult(@NonNull final IPayment paymentResult) {
+        explodingProcess = false;
         //TODO refactor
         if (getActivity() != null) {
             //TODO refactor
@@ -252,7 +259,14 @@ public class OneTapFragment extends Fragment implements OneTap.View {
     public void cancelLoading() {
         showToolbar();
         oneTapView.showButton();
+        explodingProcess = false;
+        restoreStatusBar();
         getChildFragmentManager().beginTransaction().remove(explodingFragment).commitNow();
+    }
+
+    private void restoreStatusBar() {
+        new StatusBarDecorator(getActivity().getWindow())
+            .setupStatusBarColor(ContextCompat.getColor(getContext(), R.color.px_colorPrimaryDark));
     }
 
     private void showToolbar() {
@@ -280,6 +294,7 @@ public class OneTapFragment extends Fragment implements OneTap.View {
         getChildFragmentManager().beginTransaction()
             .replace(R.id.exploding_frame, explodingFragment)
             .commitNow();
+        explodingProcess = true;
     }
 
     @Override


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
<!--- ¿Por qué este cambio es requerido? ¿Qué problema resuelve? -->
Al obtener un resultado de pago "call for authorize" o alguno que permita recuperarse, se volvía a grupos, y luego al hacer back se veía el Fragment de explosión (pintado del color con el que explotó) arriba de one tap.

## Descripción
<!--- Describir los cambios en detalle -->
Se remueve el fragment de explosión al volver a la pantalla de one tap.

## Cómo probarlo
<!--- Para bug fixes: Describir cómo reproducir el comportamiento que generaba el bug -->
<!--- Para nuevos features: Se debe agregar el caso de uso a la app de ejemplos, y aquí se debe describir qué función de la app de ejemplos probar -->
Caso 19: call for authorize
