### PR TITLE
[Fix] Null pointer with kill activities

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/CheckoutActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/CheckoutActivity.java
@@ -7,7 +7,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.mercadopago.android.px.BuildConfig;
 import com.mercadopago.android.px.R;
-import com.mercadopago.android.px.internal.callbacks.MPCall;
 import com.mercadopago.android.px.internal.datasource.MercadoPagoESCImpl;
 import com.mercadopago.android.px.internal.di.ConfigurationModule;
 import com.mercadopago.android.px.internal.di.Session;
@@ -36,17 +35,12 @@ import com.mercadopago.android.px.model.Card;
 import com.mercadopago.android.px.model.Discount;
 import com.mercadopago.android.px.model.GenericPayment;
 import com.mercadopago.android.px.model.Payment;
-import com.mercadopago.android.px.model.PaymentMethodSearch;
 import com.mercadopago.android.px.model.PaymentRecovery;
 import com.mercadopago.android.px.model.PaymentResult;
-import com.mercadopago.android.px.model.Token;
-import com.mercadopago.android.px.model.exceptions.ApiException;
 import com.mercadopago.android.px.model.exceptions.MercadoPagoError;
 import com.mercadopago.android.px.preferences.PaymentPreference;
-import com.mercadopago.android.px.services.Callback;
 import com.mercadopago.android.px.tracking.internal.MPTracker;
 import com.mercadopago.android.px.tracking.internal.utils.TrackingUtil;
-import java.io.Serializable;
 import java.math.BigDecimal;
 
 import static com.mercadopago.android.px.core.MercadoPagoCheckout.EXTRA_ERROR;
@@ -62,9 +56,6 @@ public class CheckoutActivity extends MercadoPagoBaseActivity implements Checkou
     private static final String EXTRA_PAYMENT_METHOD_CHANGED = "paymentMethodChanged";
     private static final String EXTRA_NEXT_ACTION = "nextAction";
     private static final String EXTRA_RESULT_CODE = "resultCode";
-    private static final String EXTRA_CARD = "card";
-    private static final String EXTRA_TOKEN = "token";
-    private static final String EXTRA_PERSISTENT_DATA = "extra_persistent_data";
     private static final String EXTRA_PRIVATE_KEY = "extra_private_key";
     private static final String EXTRA_PUBLIC_KEY = "extra_public_key";
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/CheckoutActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/CheckoutActivity.java
@@ -107,8 +107,12 @@ public class CheckoutActivity extends MercadoPagoBaseActivity implements Checkou
         if (savedInstanceState != null) {
             final Session session = Session.getSession(this);
             final ConfigurationModule configurationModule = session.getConfigurationModule();
+            CheckoutStateModel state = (CheckoutStateModel) getLastCustomNonConfigurationInstance();
+            if (state == null) {
+                state = new CheckoutStateModel();
+            }
             presenter =
-                new CheckoutPresenter((CheckoutStateModel) getLastCustomNonConfigurationInstance(),
+                new CheckoutPresenter(state,
                     configurationModule.getPaymentSettings(), session.getAmountRepository(),
                     configurationModule.getUserSelectionRepository(),
                     session.getDiscountRepository(),

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/CheckoutPresenter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/CheckoutPresenter.java
@@ -89,7 +89,8 @@ public class CheckoutPresenter extends MvpPresenter<CheckoutView, CheckoutProvid
         state = persistentData;
     }
 
-    public Serializable getState() {
+    @NonNull
+    public CheckoutStateModel getState() {
         return state;
     }
 
@@ -158,7 +159,7 @@ public class CheckoutPresenter extends MvpPresenter<CheckoutView, CheckoutProvid
             });
     }
 
-    private void retrievePaymentMethodSearch() {
+    public void retrievePaymentMethodSearch() {
         if (isViewAttached()) {
             groupsRepository.getGroups().enqueue(new Callback<PaymentMethodSearch>() {
                 @Override
@@ -308,7 +309,8 @@ public class CheckoutPresenter extends MvpPresenter<CheckoutView, CheckoutProvid
                         .setPaymentStatusDetail(Payment.StatusDetail.STATUS_DETAIL_PENDING_CONTINGENCY)
                         .build();
                 getView()
-                    .showPaymentResult(paymentResult, amountRepository.getAmountToPay(), discountRepository.getDiscount());
+                    .showPaymentResult(paymentResult, amountRepository.getAmountToPay(),
+                        discountRepository.getDiscount());
             } else if (mercadoPagoError.isInternalServerError()) {
                 resolveInternalServerError(mercadoPagoError);
             } else if (mercadoPagoError.isBadRequestError()) {
@@ -319,10 +321,7 @@ public class CheckoutPresenter extends MvpPresenter<CheckoutView, CheckoutProvid
         } else {
             getView().showError(mercadoPagoError);
         }
-
     }
-
-
 
     private void resolveInternalServerError(final MercadoPagoError mercadoPagoError) {
         getView().showError(mercadoPagoError);

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/viewmodel/CheckoutStateModel.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/viewmodel/CheckoutStateModel.java
@@ -1,10 +1,20 @@
 package com.mercadopago.android.px.internal.viewmodel;
 
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
 import com.mercadopago.android.px.model.IPayment;
 import com.mercadopago.android.px.model.PaymentRecovery;
-import java.io.Serializable;
 
-public final class CheckoutStateModel implements Serializable {
+public final class CheckoutStateModel {
+
+    private static final String EXTRA_PM_EDITED = "EXTRA_PM_EDITED";
+    private static final String EXTRA_EDITED_FROM_RYC = "EXTRA_EDITED_FROM_RYC";
+    private static final String EXTRA_UNIQUE_PM = "EXTRA_UNIQUE_PM";
+    private static final String EXTRA_IS_ONE_TAP = "EXTRA_IS_ONE_TAP";
+    private static final String EXTRA_RECOVERY = "EXTRA_RECOVERY";
+    private static final String EXTRA_PAYMENT = "EXTRA_PAYMENT";
+    private static final String EXTRA_PAYMENT_SERIALIZABLE = "EXTRA_PAYMENT_SERIALIZABLE";
 
     public boolean paymentMethodEdited;
     public boolean editPaymentMethodFromReviewAndConfirm;
@@ -14,5 +24,32 @@ public final class CheckoutStateModel implements Serializable {
     public IPayment createdPayment;
 
     public CheckoutStateModel() {
+    }
+
+    public void toBundle(@NonNull final Bundle bundle) {
+        bundle.putBoolean(EXTRA_PM_EDITED, paymentMethodEdited);
+        bundle.putBoolean(EXTRA_EDITED_FROM_RYC, editPaymentMethodFromReviewAndConfirm);
+        bundle.putBoolean(EXTRA_UNIQUE_PM, isUniquePaymentMethod);
+        bundle.putBoolean(EXTRA_IS_ONE_TAP, isOneTap);
+        bundle.putSerializable(EXTRA_RECOVERY, paymentRecovery);
+        if (createdPayment instanceof Parcelable) {
+            bundle.putParcelable(EXTRA_PAYMENT, (Parcelable) createdPayment);
+        } else {
+            bundle.putSerializable(EXTRA_PAYMENT_SERIALIZABLE, createdPayment);
+        }
+    }
+
+    public static CheckoutStateModel fromBundle(@NonNull final Bundle bundle) {
+        final CheckoutStateModel stateModel = new CheckoutStateModel();
+        stateModel.paymentMethodEdited = bundle.getBoolean(EXTRA_PM_EDITED);
+        stateModel.editPaymentMethodFromReviewAndConfirm = bundle.getBoolean(EXTRA_EDITED_FROM_RYC);
+        stateModel.isUniquePaymentMethod = bundle.getBoolean(EXTRA_UNIQUE_PM);
+        stateModel.isOneTap = bundle.getBoolean(EXTRA_IS_ONE_TAP);
+        if (bundle.containsKey(EXTRA_PAYMENT)) {
+            stateModel.createdPayment = bundle.getParcelable(EXTRA_PAYMENT);
+        } else if (bundle.containsKey(EXTRA_PAYMENT_SERIALIZABLE)) {
+            stateModel.createdPayment = (IPayment) bundle.getSerializable(EXTRA_PAYMENT_SERIALIZABLE);
+        }
+        return stateModel;
     }
 }


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
<!--- ¿Por qué este cambio es requerido? ¿Qué problema resuelve? -->
Con "Eliminar Actividades" activado, estaba crasheando por no tener el CheckoutStateModel.
## Descripción
<!--- Describir los cambios en detalle -->
Se inicializa el CheckoutStateModel si no se puede recuperar.
## Cómo probarlo
<!--- Para bug fixes: Describir cómo reproducir el comportamiento que generaba el bug -->
<!--- Para nuevos features: Se debe agregar el caso de uso a la app de ejemplos, y aquí se debe describir qué función de la app de ejemplos probar -->
Caso Business - Complete - Approved
## Screenshots
<!--- Para bug fixes: Incluir screenshots o videos del antes y después -->
<!--- Para nuevos features: Incluir screenshots o videos de la nueva UI -->

## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
https://medium.com/@trionkidnapper/android-mvp-keeping-presenters-alive-a91b9e080761
