### PR TITLE
[feature] dynamic fragments for screen locations

### DIFF
--- a/example/src/main/java/com/mercadopago/SampleTopFragment.java
+++ b/example/src/main/java/com/mercadopago/SampleTopFragment.java
@@ -62,7 +62,11 @@ public class SampleTopFragment extends Fragment {
     public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         TextView textView = view.findViewById(R.id.textView);
-        ParcelableArgument arg = getArguments().getParcelable(SOME_PARCELABLE);
-        textView.setText(arg.label);
+        if (getArguments() != null && getArguments().containsKey(SOME_PARCELABLE)) {
+            ParcelableArgument arg = getArguments().getParcelable(SOME_PARCELABLE);
+            textView.setText(arg.label);
+        } else {
+            textView.setText("NO ARGS!");
+        }
     }
 }

--- a/example/src/main/java/com/mercadopago/android/px/internal/features/plugins/SampleDialog.java
+++ b/example/src/main/java/com/mercadopago/android/px/internal/features/plugins/SampleDialog.java
@@ -1,0 +1,20 @@
+package com.mercadopago.android.px.internal.features.plugins;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.DialogFragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import com.mercadopago.example.R;
+
+public class SampleDialog extends DialogFragment {
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull final LayoutInflater inflater, @Nullable final ViewGroup container,
+        @Nullable final Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.sample_dialog, container, false);
+    }
+}

--- a/example/src/main/java/com/mercadopago/android/px/utils/ExamplesUtils.java
+++ b/example/src/main/java/com/mercadopago/android/px/utils/ExamplesUtils.java
@@ -1,21 +1,26 @@
 package com.mercadopago.android.px.utils;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.util.Pair;
 import android.util.Log;
 import android.widget.Toast;
 import com.mercadopago.SampleTopFragment;
 import com.mercadopago.android.px.configuration.AdvancedConfiguration;
+import com.mercadopago.android.px.configuration.DynamicDialogConfiguration;
 import com.mercadopago.android.px.configuration.DynamicFragmentConfiguration;
 import com.mercadopago.android.px.configuration.ReviewAndConfirmConfiguration;
+import com.mercadopago.android.px.core.DynamicDialogCreator;
 import com.mercadopago.android.px.core.DynamicFragmentCreator;
 import com.mercadopago.android.px.core.MercadoPagoCheckout;
 import com.mercadopago.android.px.core.MercadoPagoCheckout.Builder;
+import com.mercadopago.android.px.internal.features.plugins.SampleDialog;
 import com.mercadopago.android.px.internal.util.ViewUtils;
 import com.mercadopago.android.px.model.Item;
 import com.mercadopago.android.px.model.Payment;
@@ -184,18 +189,46 @@ public final class ExamplesUtils {
         return new Builder(DUMMY_MERCHANT_PUBLIC_KEY, DUMMY_PREFERENCE_ID_WITH_TWO_ITEMS)
             .setAdvancedConfiguration(new AdvancedConfiguration.Builder()
                 .setReviewAndConfirmConfiguration(preferences)
-                .setDynamicFragmentConfiguration(new DynamicFragmentConfiguration.Builder()
-                    .addDynamicCreator(
-                        DynamicFragmentConfiguration.FragmentLocation.TOP_PAYMENT_METHOD_REVIEW_AND_CONFIRM,
-                        new DynamicFragmentCreator() {
+                .setDynamicDialogConfiguration(new DynamicDialogConfiguration.Builder()
+                    .addDynamicCreator(DynamicDialogConfiguration.DialogLocation.ENTER_REVIEW_AND_CONFIRM,
+                        new DynamicDialogCreator() {
                             @Override
-                            public boolean shouldShowFragment(@NonNull final CheckoutData checkoutData) {
+                            public boolean shouldShowDialog(@NonNull final Context context,
+                                @NonNull final CheckoutData checkoutData) {
                                 return true;
                             }
 
                             @NonNull
                             @Override
-                            public Fragment create(@NonNull final CheckoutData checkoutData) {
+                            public DialogFragment create(@NonNull final Context context,
+                                @NonNull final CheckoutData checkoutData) {
+                                return new SampleDialog();
+                            }
+
+                            @Override
+                            public int describeContents() {
+                                return 0;
+                            }
+
+                            @Override
+                            public void writeToParcel(final Parcel dest, final int flags) {
+
+                            }
+                        }).build())
+                .setDynamicFragmentConfiguration(new DynamicFragmentConfiguration.Builder()
+                    .addDynamicCreator(
+                        DynamicFragmentConfiguration.FragmentLocation.TOP_PAYMENT_METHOD_REVIEW_AND_CONFIRM,
+                        new DynamicFragmentCreator() {
+                            @Override
+                            public boolean shouldShowFragment(@NonNull final Context context,
+                                @NonNull final CheckoutData checkoutData) {
+                                return true;
+                            }
+
+                            @NonNull
+                            @Override
+                            public Fragment create(@NonNull final Context context,
+                                @NonNull final CheckoutData checkoutData) {
                                 return new SampleTopFragment();
                             }
 

--- a/example/src/main/java/com/mercadopago/android/px/utils/ExamplesUtils.java
+++ b/example/src/main/java/com/mercadopago/android/px/utils/ExamplesUtils.java
@@ -3,13 +3,17 @@ package com.mercadopago.android.px.utils;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Parcel;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.util.Pair;
 import android.util.Log;
 import android.widget.Toast;
+import com.mercadopago.SampleTopFragment;
 import com.mercadopago.android.px.configuration.AdvancedConfiguration;
+import com.mercadopago.android.px.configuration.DynamicFragmentConfiguration;
 import com.mercadopago.android.px.configuration.ReviewAndConfirmConfiguration;
+import com.mercadopago.android.px.core.DynamicFragmentCreator;
 import com.mercadopago.android.px.core.MercadoPagoCheckout;
 import com.mercadopago.android.px.core.MercadoPagoCheckout.Builder;
 import com.mercadopago.android.px.internal.util.ViewUtils;
@@ -180,6 +184,31 @@ public final class ExamplesUtils {
         return new Builder(DUMMY_MERCHANT_PUBLIC_KEY, DUMMY_PREFERENCE_ID_WITH_TWO_ITEMS)
             .setAdvancedConfiguration(new AdvancedConfiguration.Builder()
                 .setReviewAndConfirmConfiguration(preferences)
+                .setDynamicFragmentConfiguration(new DynamicFragmentConfiguration.Builder()
+                    .addDynamicCreator(
+                        DynamicFragmentConfiguration.FragmentLocation.TOP_PAYMENT_METHOD_REVIEW_AND_CONFIRM,
+                        new DynamicFragmentCreator() {
+                            @Override
+                            public boolean shouldShowFragment(@NonNull final CheckoutData checkoutData) {
+                                return true;
+                            }
+
+                            @NonNull
+                            @Override
+                            public Fragment create(@NonNull final CheckoutData checkoutData) {
+                                return new SampleTopFragment();
+                            }
+
+                            @Override
+                            public int describeContents() {
+                                return 0;
+                            }
+
+                            @Override
+                            public void writeToParcel(final Parcel dest, final int flags) {
+
+                            }
+                        }).build())
                 .build());
     }
 

--- a/example/src/main/res/layout/sample_dialog.xml
+++ b/example/src/main/res/layout/sample_dialog.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                             android:layout_width="match_parent"
+                                             android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/app_name"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/px-checkout/src/main/java/com/mercadopago/android/px/configuration/AdvancedConfiguration.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/configuration/AdvancedConfiguration.java
@@ -19,6 +19,7 @@ public class AdvancedConfiguration implements Serializable {
     @NonNull private final PaymentResultScreenConfiguration paymentResultScreenConfiguration;
     @NonNull private final ReviewAndConfirmConfiguration reviewAndConfirmConfiguration;
     @NonNull private final DynamicFragmentConfiguration dynamicFragmentConfiguration;
+    @NonNull private final DynamicDialogConfiguration dynamicDialogConfiguration;
 
     /* default */ AdvancedConfiguration(final Builder builder) {
         bankDealsEnabled = builder.bankDealsEnabled;
@@ -26,6 +27,7 @@ public class AdvancedConfiguration implements Serializable {
         paymentResultScreenConfiguration = builder.paymentResultScreenConfiguration;
         reviewAndConfirmConfiguration = builder.reviewAndConfirmConfiguration;
         dynamicFragmentConfiguration = builder.dynamicFragmentConfiguration;
+        dynamicDialogConfiguration = builder.dynamicDialogConfiguration;
     }
 
     public boolean isBankDealsEnabled() {
@@ -39,6 +41,11 @@ public class AdvancedConfiguration implements Serializable {
     @NonNull
     public DynamicFragmentConfiguration getDynamicFragmentConfiguration() {
         return dynamicFragmentConfiguration;
+    }
+
+    @NonNull
+    public DynamicDialogConfiguration getDynamicDialogConfiguration() {
+        return dynamicDialogConfiguration;
     }
 
     @NonNull
@@ -61,6 +68,10 @@ public class AdvancedConfiguration implements Serializable {
             new ReviewAndConfirmConfiguration.Builder().build();
         /* default */ @NonNull DynamicFragmentConfiguration dynamicFragmentConfiguration =
             new DynamicFragmentConfiguration.Builder().build();
+        /* default */ @NonNull DynamicDialogConfiguration dynamicDialogConfiguration =
+            new DynamicDialogConfiguration.Builder().build();
+
+
 
         /**
          * Add the possibility to configure Bank's deals behaviour.
@@ -119,12 +130,25 @@ public class AdvancedConfiguration implements Serializable {
          * Enable to preset configurations to customize dynamic visualization on
          * several screen locations see {@link DynamicFragmentConfiguration.Builder}
          *
-         * @param dynamicFragmentConfiguration your custom preferences.
+         * @param dynamicFragmentConfiguration your custom configurations.
          * @return builder to keep operating
          */
         public Builder setDynamicFragmentConfiguration(
             @NonNull final DynamicFragmentConfiguration dynamicFragmentConfiguration) {
             this.dynamicFragmentConfiguration = dynamicFragmentConfiguration;
+            return this;
+        }
+
+        /**
+         * Enable to preset configurations to customize dynamic visualization on
+         * several screen locations see {@link DynamicFragmentConfiguration.Builder}
+         *
+         * @param dynamicDialogConfiguration your custom configurations.
+         * @return builder to keep operating
+         */
+        public Builder setDynamicDialogConfiguration(
+            @NonNull final DynamicDialogConfiguration dynamicDialogConfiguration) {
+            this.dynamicDialogConfiguration = dynamicDialogConfiguration;
             return this;
         }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/configuration/AdvancedConfiguration.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/configuration/AdvancedConfiguration.java
@@ -18,12 +18,14 @@ public class AdvancedConfiguration implements Serializable {
     private final boolean escEnabled;
     @NonNull private final PaymentResultScreenConfiguration paymentResultScreenConfiguration;
     @NonNull private final ReviewAndConfirmConfiguration reviewAndConfirmConfiguration;
+    @NonNull private final DynamicFragmentConfiguration dynamicFragmentConfiguration;
 
     /* default */ AdvancedConfiguration(final Builder builder) {
         bankDealsEnabled = builder.bankDealsEnabled;
         escEnabled = builder.escEnabled;
         paymentResultScreenConfiguration = builder.paymentResultScreenConfiguration;
         reviewAndConfirmConfiguration = builder.reviewAndConfirmConfiguration;
+        dynamicFragmentConfiguration = builder.dynamicFragmentConfiguration;
     }
 
     public boolean isBankDealsEnabled() {
@@ -32,6 +34,11 @@ public class AdvancedConfiguration implements Serializable {
 
     public boolean isEscEnabled() {
         return escEnabled;
+    }
+
+    @NonNull
+    public DynamicFragmentConfiguration getDynamicFragmentConfiguration() {
+        return dynamicFragmentConfiguration;
     }
 
     @NonNull
@@ -52,6 +59,8 @@ public class AdvancedConfiguration implements Serializable {
             new PaymentResultScreenConfiguration.Builder().build();
         /* default */ @NonNull ReviewAndConfirmConfiguration reviewAndConfirmConfiguration =
             new ReviewAndConfirmConfiguration.Builder().build();
+        /* default */ @NonNull DynamicFragmentConfiguration dynamicFragmentConfiguration =
+            new DynamicFragmentConfiguration.Builder().build();
 
         /**
          * Add the possibility to configure Bank's deals behaviour.
@@ -103,6 +112,19 @@ public class AdvancedConfiguration implements Serializable {
         public Builder setReviewAndConfirmConfiguration(
             @NonNull final ReviewAndConfirmConfiguration reviewAndConfirmConfiguration) {
             this.reviewAndConfirmConfiguration = reviewAndConfirmConfiguration;
+            return this;
+        }
+
+        /**
+         * Enable to preset configurations to customize dynamic visualization on
+         * several screen locations see {@link DynamicFragmentConfiguration.Builder}
+         *
+         * @param dynamicFragmentConfiguration your custom preferences.
+         * @return builder to keep operating
+         */
+        public Builder setDynamicFragmentConfiguration(
+            @NonNull final DynamicFragmentConfiguration dynamicFragmentConfiguration) {
+            this.dynamicFragmentConfiguration = dynamicFragmentConfiguration;
             return this;
         }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/configuration/DynamicDialogConfiguration.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/configuration/DynamicDialogConfiguration.java
@@ -1,0 +1,55 @@
+package com.mercadopago.android.px.configuration;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import com.mercadopago.android.px.core.DynamicDialogCreator;
+import java.util.HashMap;
+import java.util.Map;
+
+// Used by single player to inform charges and other payment special information.
+// Single player usecase depends on amount and payment method.
+@SuppressWarnings("unused")
+public final class DynamicDialogConfiguration {
+
+    private final Map<DialogLocation, DynamicDialogCreator> creators;
+
+    public enum DialogLocation {
+        ENTER_REVIEW_AND_CONFIRM,
+    }
+
+    /* default */ DynamicDialogConfiguration(@NonNull final Builder builder) {
+        creators = builder.creators;
+    }
+
+    @Nullable
+    public DynamicDialogCreator getCreatorFor(@NonNull final DialogLocation dialogLocation) {
+        return creators.get(dialogLocation);
+    }
+
+    public boolean hasCreatorFor(@NonNull final DialogLocation fragmentLocation) {
+        return creators.containsKey(fragmentLocation);
+    }
+
+    public static final class Builder {
+
+        /* default */ Map<DialogLocation, DynamicDialogCreator> creators;
+
+        public Builder() {
+            creators = new HashMap<>();
+        }
+
+        /**
+         * @param location where dynamic dialog will be placed.
+         * @param dynamicDialogCreator your creator.
+         */
+        public Builder addDynamicCreator(@NonNull final DialogLocation location,
+            @NonNull final DynamicDialogCreator dynamicDialogCreator) {
+            creators.put(location, dynamicDialogCreator);
+            return this;
+        }
+
+        public DynamicDialogConfiguration build() {
+            return new DynamicDialogConfiguration(this);
+        }
+    }
+}

--- a/px-checkout/src/main/java/com/mercadopago/android/px/configuration/DynamicFragmentConfiguration.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/configuration/DynamicFragmentConfiguration.java
@@ -6,6 +6,8 @@ import com.mercadopago.android.px.core.DynamicFragmentCreator;
 import java.util.HashMap;
 import java.util.Map;
 
+// Used by single player to inform charges and other payment special information.
+// Single player usecase depends on amount and payment method.
 @SuppressWarnings("unused")
 public final class DynamicFragmentConfiguration {
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/configuration/DynamicFragmentConfiguration.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/configuration/DynamicFragmentConfiguration.java
@@ -1,0 +1,54 @@
+package com.mercadopago.android.px.configuration;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import com.mercadopago.android.px.core.DynamicFragmentCreator;
+import java.util.HashMap;
+import java.util.Map;
+
+@SuppressWarnings("unused")
+public final class DynamicFragmentConfiguration {
+
+    private final Map<FragmentLocation, DynamicFragmentCreator> creators;
+
+    public enum FragmentLocation {
+        TOP_PAYMENT_METHOD_REVIEW_AND_CONFIRM,
+        BOTTOM_PAYMENT_METHOD_REVIEW_AND_CONFIRM
+    }
+
+    /* default */ DynamicFragmentConfiguration(@NonNull final Builder builder) {
+        creators = builder.creators;
+    }
+
+    @Nullable
+    public DynamicFragmentCreator getCreatorFor(@NonNull final FragmentLocation fragmentLocation) {
+        return creators.get(fragmentLocation);
+    }
+
+    public boolean hasCreatorFor(@NonNull final FragmentLocation fragmentLocation) {
+        return creators.containsKey(fragmentLocation);
+    }
+
+    public static final class Builder {
+
+        /* default */ Map<FragmentLocation, DynamicFragmentCreator> creators;
+
+        public Builder() {
+            creators = new HashMap<>();
+        }
+
+        /**
+         * @param location where dynamic fragment will be placed.
+         * @param dynamicFragmentCreator your creator.
+         */
+        public Builder addDynamicCreator(@NonNull final FragmentLocation location,
+            @NonNull final DynamicFragmentCreator dynamicFragmentCreator) {
+            creators.put(location, dynamicFragmentCreator);
+            return this;
+        }
+
+        public DynamicFragmentConfiguration build() {
+            return new DynamicFragmentConfiguration(this);
+        }
+    }
+}

--- a/px-checkout/src/main/java/com/mercadopago/android/px/configuration/ReviewAndConfirmConfiguration.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/configuration/ReviewAndConfirmConfiguration.java
@@ -5,6 +5,7 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import com.mercadopago.android.px.core.DynamicFragmentCreator;
 import com.mercadopago.android.px.model.ExternalFragment;
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -12,9 +13,11 @@ import java.math.BigDecimal;
 @SuppressWarnings("unused")
 public class ReviewAndConfirmConfiguration implements Serializable {
 
+    @Deprecated
     @Nullable
     private final ExternalFragment topFragment;
 
+    @Deprecated
     @Nullable
     private final ExternalFragment bottomFragment;
 
@@ -192,9 +195,11 @@ public class ReviewAndConfirmConfiguration implements Serializable {
 
     public static final class Builder {
 
+        @Deprecated
         @Nullable
         ExternalFragment topFragment;
 
+        @Deprecated
         @Nullable
         ExternalFragment bottomFragment;
 
@@ -231,7 +236,10 @@ public class ReviewAndConfirmConfiguration implements Serializable {
          * @param zClass Fragment class
          * @param args Bundle for fragment
          * @return builder
+         * @deprecated will be deprecated on V5 {Replaced by
+         *    {@link DynamicFragmentConfiguration.Builder#addDynamicCreator(DynamicFragmentConfiguration.FragmentLocation, DynamicFragmentCreator)}
          */
+        @Deprecated
         public Builder setTopFragment(@NonNull final Class<? extends Fragment> zClass, @Nullable final Bundle args) {
             topFragment = new ExternalFragment(zClass, args);
             return this;
@@ -242,8 +250,10 @@ public class ReviewAndConfirmConfiguration implements Serializable {
          *
          * @param zClass Fragment class
          * @param args Bundle for fragment
-         * @return builder
+         * @deprecated will be deprecated on V5 {Replaced by
+         *    {@link DynamicFragmentConfiguration.Builder#addDynamicCreator(DynamicFragmentConfiguration.FragmentLocation, DynamicFragmentCreator)}
          */
+        @Deprecated
         public Builder setBottomFragment(@NonNull final Class<? extends Fragment> zClass, @Nullable final Bundle args) {
             bottomFragment = new ExternalFragment(zClass, args);
             return this;

--- a/px-checkout/src/main/java/com/mercadopago/android/px/core/DynamicDialogCreator.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/core/DynamicDialogCreator.java
@@ -1,5 +1,6 @@
 package com.mercadopago.android.px.core;
 
+import android.content.Context;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
@@ -27,14 +28,14 @@ public interface DynamicDialogCreator extends Parcelable {
      * asked to be shown.
      *
      * @param checkoutData
-     * @return
+     * @return if dialog should be shown.
      */
-    boolean shouldShowDialog(@NonNull final CheckoutData checkoutData);
+    boolean shouldShowDialog(@NonNull final Context context, @NonNull final CheckoutData checkoutData);
 
     /**
      * @param checkoutData available data
      * @return yourDialog
      */
     @NonNull
-    DialogFragment create(@NonNull final CheckoutData checkoutData);
+    DialogFragment create(@NonNull final Context context, @NonNull final CheckoutData checkoutData);
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/core/DynamicDialogCreator.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/core/DynamicDialogCreator.java
@@ -2,11 +2,11 @@ package com.mercadopago.android.px.core;
 
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
-import android.support.v4.app.Fragment;
+import android.support.v4.app.DialogFragment;
 import com.mercadopago.android.px.model.PaymentData;
 import com.mercadopago.android.px.preferences.CheckoutPreference;
 
-public interface DynamicFragmentCreator extends Parcelable {
+public interface DynamicDialogCreator extends Parcelable {
 
     /* default */ final class CheckoutData {
 
@@ -23,18 +23,18 @@ public interface DynamicFragmentCreator extends Parcelable {
     }
 
     /**
-     * if true is returned then create will be called and fragment the fragment will be
-     * placed.
+     * if true is returned then create will be called and dialog will be
+     * asked to be shown.
      *
      * @param checkoutData
      * @return
      */
-    boolean shouldShowFragment(@NonNull final CheckoutData checkoutData);
+    boolean shouldShowDialog(@NonNull final CheckoutData checkoutData);
 
     /**
      * @param checkoutData available data
-     * @return yourCustomDynamicFragment
+     * @return yourDialog
      */
     @NonNull
-    Fragment create(@NonNull final CheckoutData checkoutData);
+    DialogFragment create(@NonNull final CheckoutData checkoutData);
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/core/DynamicFragmentCreator.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/core/DynamicFragmentCreator.java
@@ -1,5 +1,6 @@
 package com.mercadopago.android.px.core;
 
+import android.content.Context;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
@@ -29,12 +30,12 @@ public interface DynamicFragmentCreator extends Parcelable {
      * @param checkoutData
      * @return
      */
-    boolean shouldShowFragment(@NonNull final CheckoutData checkoutData);
+    boolean shouldShowFragment(@NonNull final Context context, @NonNull final CheckoutData checkoutData);
 
     /**
      * @param checkoutData available data
      * @return yourCustomDynamicFragment
      */
     @NonNull
-    Fragment create(@NonNull final CheckoutData checkoutData);
+    Fragment create(@NonNull final Context context, @NonNull final CheckoutData checkoutData);
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/core/DynamicFragmentCreator.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/core/DynamicFragmentCreator.java
@@ -1,0 +1,42 @@
+package com.mercadopago.android.px.core;
+
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import com.mercadopago.android.px.model.PaymentMethod;
+import com.mercadopago.android.px.preferences.CheckoutPreference;
+
+public interface DynamicFragmentCreator extends Parcelable {
+
+    final class CheckoutData {
+
+        @Nullable
+        public final CheckoutPreference checkoutPreference;
+
+        @Nullable
+        public final PaymentMethod selectedPaymentMethod;
+
+        public CheckoutData(@Nullable final CheckoutPreference checkoutPreference,
+            @Nullable final PaymentMethod selectedPaymentMethod) {
+            this.checkoutPreference = checkoutPreference;
+            this.selectedPaymentMethod = selectedPaymentMethod;
+        }
+    }
+
+    /**
+     * if true is returned then create will be called and fragment the fragment will be
+     * placed.
+     *
+     * @param checkoutData
+     * @return
+     */
+    boolean shouldShowFragment(@NonNull final CheckoutData checkoutData);
+
+    /**
+     * @param checkoutData available data
+     * @return yourCustomDynamicFragment
+     */
+    @NonNull
+    Fragment create(@NonNull final CheckoutData checkoutData);
+}

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirm.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirm.java
@@ -1,6 +1,7 @@
 package com.mercadopago.android.px.internal.features.review_and_confirm;
 
 import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
 import com.mercadopago.android.px.internal.base.MvpView;
 import com.mercadopago.android.px.internal.callbacks.PaymentServiceHandler;
 import com.mercadopago.android.px.internal.features.explode.ExplodeDecorator;
@@ -44,6 +45,8 @@ public interface ReviewAndConfirm {
         void showConfirmButton();
 
         void showErrorSnackBar(@NonNull final MercadoPagoError error);
+
+        void showDynamicDialog(DialogFragment dialogFragment);
     }
 
     interface Action extends PaymentServiceHandler {

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirm.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirm.java
@@ -1,7 +1,7 @@
 package com.mercadopago.android.px.internal.features.review_and_confirm;
 
 import android.support.annotation.NonNull;
-import android.support.v4.app.DialogFragment;
+import com.mercadopago.android.px.core.DynamicDialogCreator;
 import com.mercadopago.android.px.internal.base.MvpView;
 import com.mercadopago.android.px.internal.callbacks.PaymentServiceHandler;
 import com.mercadopago.android.px.internal.features.explode.ExplodeDecorator;
@@ -46,7 +46,8 @@ public interface ReviewAndConfirm {
 
         void showErrorSnackBar(@NonNull final MercadoPagoError error);
 
-        void showDynamicDialog(DialogFragment dialogFragment);
+        void showDynamicDialog(@NonNull final DynamicDialogCreator creator,
+            @NonNull final DynamicDialogCreator.CheckoutData checkoutData);
     }
 
     interface Action extends PaymentServiceHandler {
@@ -62,8 +63,8 @@ public interface ReviewAndConfirm {
 
         void recoverFromFailure();
 
-
-
         void executePostPaymentAction(@NonNull PostPaymentAction postPaymentAction);
+
+        void onViewResumed(View view);
     }
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmActivity.java
@@ -8,7 +8,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.CollapsingToolbarLayout;
 import android.support.design.widget.Snackbar;
-import android.support.v4.app.DialogFragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.Toolbar;
@@ -19,6 +18,7 @@ import com.mercadolibre.android.ui.widgets.MeliSnackbar;
 import com.mercadopago.android.px.R;
 import com.mercadopago.android.px.configuration.AdvancedConfiguration;
 import com.mercadopago.android.px.configuration.ReviewAndConfirmConfiguration;
+import com.mercadopago.android.px.core.DynamicDialogCreator;
 import com.mercadopago.android.px.internal.di.Session;
 import com.mercadopago.android.px.internal.features.Constants;
 import com.mercadopago.android.px.internal.features.MercadoPagoBaseActivity;
@@ -166,8 +166,8 @@ public final class ReviewAndConfirmActivity extends MercadoPagoBaseActivity impl
 
     @Override
     protected void onResume() {
-        presenter.attachView(this);
         super.onResume();
+        presenter.onViewResumed(this);
     }
 
     @Override
@@ -560,7 +560,10 @@ public final class ReviewAndConfirmActivity extends MercadoPagoBaseActivity impl
     }
 
     @Override
-    public void showDynamicDialog(final DialogFragment dialogFragment) {
-        dialogFragment.show(getSupportFragmentManager(), TAG_DYNAMIC_DIALOG);
+    public void showDynamicDialog(@NonNull final DynamicDialogCreator creator,
+        @NonNull final DynamicDialogCreator.CheckoutData checkoutData) {
+        if (creator.shouldShowDialog(this, checkoutData)) {
+            creator.create(this, checkoutData).show(getSupportFragmentManager(), TAG_DYNAMIC_DIALOG);
+        }
     }
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmActivity.java
@@ -16,6 +16,7 @@ import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import com.mercadolibre.android.ui.widgets.MeliSnackbar;
 import com.mercadopago.android.px.R;
+import com.mercadopago.android.px.configuration.AdvancedConfiguration;
 import com.mercadopago.android.px.configuration.ReviewAndConfirmConfiguration;
 import com.mercadopago.android.px.internal.di.Session;
 import com.mercadopago.android.px.internal.features.Constants;
@@ -183,7 +184,6 @@ public final class ReviewAndConfirmActivity extends MercadoPagoBaseActivity impl
                     resolveCardVaultRequest(resultCode, data);
                 }
             });
-
             break;
         case ErrorUtil.ERROR_REQUEST_CODE:
             resolveErrorRequest(resultCode, data);
@@ -310,9 +310,12 @@ public final class ReviewAndConfirmActivity extends MercadoPagoBaseActivity impl
             final TermsAndConditionsModel discountTermsAndConditions =
                 extras.getParcelable(EXTRA_DISCOUNT_TERMS_AND_CONDITIONS);
 
+            final Session session = Session.getSession(this);
+            final AdvancedConfiguration advancedConfiguration = session.getConfigurationModule().getPaymentSettings()
+                .getAdvancedConfiguration();
+
             final ReviewAndConfirmConfiguration reviewAndConfirmConfiguration =
-                Session.getSession(this).getConfigurationModule().getPaymentSettings()
-                    .getAdvancedConfiguration().getReviewAndConfirmConfiguration();
+                advancedConfiguration.getReviewAndConfirmConfiguration();
 
             Tracker.trackReviewAndConfirmScreen(getApplicationContext(),
                 paymentModel);
@@ -320,6 +323,7 @@ public final class ReviewAndConfirmActivity extends MercadoPagoBaseActivity impl
                 paymentModel,
                 summaryModel,
                 reviewAndConfirmConfiguration,
+                advancedConfiguration.getDynamicFragmentConfiguration(),
                 itemsModel, discountTermsAndConditions);
         }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmActivity.java
@@ -8,6 +8,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.CollapsingToolbarLayout;
 import android.support.design.widget.Snackbar;
+import android.support.v4.app.DialogFragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.Toolbar;
@@ -68,6 +69,7 @@ public final class ReviewAndConfirmActivity extends MercadoPagoBaseActivity impl
     private static final String EXTRA_PUBLIC_KEY = "extra_public_key";
     private static final String EXTRA_ITEMS = "extra_items";
     private static final String EXTRA_DISCOUNT_TERMS_AND_CONDITIONS = "extra_discount_terms_and_conditions";
+    private static final String TAG_DYNAMIC_DIALOG = "tag_dynamic_dialog";
 
     /* default */ ReviewAndConfirmPresenter presenter;
 
@@ -126,7 +128,12 @@ public final class ReviewAndConfirmActivity extends MercadoPagoBaseActivity impl
         initializeViews();
         final Session session = Session.getSession(this);
         presenter = new ReviewAndConfirmPresenter(session.getPaymentRepository(),
-            session.getBusinessModelMapper());
+            session.getBusinessModelMapper(),
+            session.getConfigurationModule()
+                .getPaymentSettings()
+                .getAdvancedConfiguration()
+                .getDynamicDialogConfiguration(),
+            session.getConfigurationModule().getPaymentSettings().getCheckoutPreference());
         presenter.attachView(this);
 
         if (savedInstanceState == null) {
@@ -550,5 +557,10 @@ public final class ReviewAndConfirmActivity extends MercadoPagoBaseActivity impl
         MeliSnackbar.make(floatingConfirmLayout, error.getMessage(), Snackbar.LENGTH_LONG,
             MeliSnackbar.SnackbarType.ERROR).show();
         Tracker.trackError(getApplicationContext(), error);
+    }
+
+    @Override
+    public void showDynamicDialog(final DialogFragment dialogFragment) {
+        dialogFragment.show(getSupportFragmentManager(), TAG_DYNAMIC_DIALOG);
     }
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmPresenter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmPresenter.java
@@ -10,6 +10,7 @@ import com.mercadopago.android.px.internal.features.explode.ExplodeDecoratorMapp
 import com.mercadopago.android.px.internal.features.explode.ExplodingFragment;
 import com.mercadopago.android.px.internal.repository.PaymentRepository;
 import com.mercadopago.android.px.internal.viewmodel.PostPaymentAction;
+import com.mercadopago.android.px.internal.viewmodel.mappers.BusinessModelMapper;
 import com.mercadopago.android.px.model.BusinessPayment;
 import com.mercadopago.android.px.model.Card;
 import com.mercadopago.android.px.model.GenericPayment;
@@ -18,7 +19,6 @@ import com.mercadopago.android.px.model.PaymentRecovery;
 import com.mercadopago.android.px.model.PaymentResult;
 import com.mercadopago.android.px.model.exceptions.MercadoPagoError;
 import com.mercadopago.android.px.preferences.CheckoutPreference;
-import com.mercadopago.android.px.internal.viewmodel.mappers.BusinessModelMapper;
 
 /* default */ final class ReviewAndConfirmPresenter extends MvpPresenter<ReviewAndConfirm.View, DefaultProvider>
     implements ReviewAndConfirm.Action {
@@ -45,17 +45,19 @@ import com.mercadopago.android.px.internal.viewmodel.mappers.BusinessModelMapper
     public void attachView(final ReviewAndConfirm.View view) {
         super.attachView(view);
         paymentRepository.attach(this);
+    }
+
+    @Override
+    public void onViewResumed(final ReviewAndConfirm.View view) {
+        attachView(view);
         resolveDynamicDialog(DynamicDialogConfiguration.DialogLocation.ENTER_REVIEW_AND_CONFIRM);
     }
 
     private void resolveDynamicDialog(@NonNull final DynamicDialogConfiguration.DialogLocation location) {
         final DynamicDialogCreator.CheckoutData checkoutData =
             new DynamicDialogCreator.CheckoutData(checkoutPreference, paymentRepository.getPaymentData());
-        if (dynamicDialogConfiguration.hasCreatorFor(location) &&
-            dynamicDialogConfiguration.getCreatorFor(location).shouldShowDialog(checkoutData)) {
-            getView().showDynamicDialog(
-                dynamicDialogConfiguration.getCreatorFor(location)
-                    .create(checkoutData));
+        if (dynamicDialogConfiguration.hasCreatorFor(location)) {
+            getView().showDynamicDialog(dynamicDialogConfiguration.getCreatorFor(location), checkoutData);
         }
     }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmPresenter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmPresenter.java
@@ -1,6 +1,8 @@
 package com.mercadopago.android.px.internal.features.review_and_confirm;
 
 import android.support.annotation.NonNull;
+import com.mercadopago.android.px.configuration.DynamicDialogConfiguration;
+import com.mercadopago.android.px.core.DynamicDialogCreator;
 import com.mercadopago.android.px.internal.base.DefaultProvider;
 import com.mercadopago.android.px.internal.base.MvpPresenter;
 import com.mercadopago.android.px.internal.callbacks.FailureRecovery;
@@ -15,6 +17,7 @@ import com.mercadopago.android.px.model.Payment;
 import com.mercadopago.android.px.model.PaymentRecovery;
 import com.mercadopago.android.px.model.PaymentResult;
 import com.mercadopago.android.px.model.exceptions.MercadoPagoError;
+import com.mercadopago.android.px.preferences.CheckoutPreference;
 import com.mercadopago.android.px.internal.viewmodel.mappers.BusinessModelMapper;
 
 /* default */ final class ReviewAndConfirmPresenter extends MvpPresenter<ReviewAndConfirm.View, DefaultProvider>
@@ -22,13 +25,19 @@ import com.mercadopago.android.px.internal.viewmodel.mappers.BusinessModelMapper
 
     @NonNull private final PaymentRepository paymentRepository;
     @NonNull private final BusinessModelMapper businessModelMapper;
+    @NonNull private final DynamicDialogConfiguration dynamicDialogConfiguration;
+    @NonNull private final CheckoutPreference checkoutPreference;
     private final ExplodeDecoratorMapper explodeDecoratorMapper;
     private FailureRecovery recovery;
 
     /* default */ ReviewAndConfirmPresenter(@NonNull final PaymentRepository paymentRepository,
-        @NonNull final BusinessModelMapper businessModelMapper) {
+        @NonNull final BusinessModelMapper businessModelMapper,
+        @NonNull final DynamicDialogConfiguration dynamicDialogConfiguration,
+        @NonNull final CheckoutPreference checkoutPreference) {
         this.paymentRepository = paymentRepository;
         this.businessModelMapper = businessModelMapper;
+        this.dynamicDialogConfiguration = dynamicDialogConfiguration;
+        this.checkoutPreference = checkoutPreference;
         explodeDecoratorMapper = new ExplodeDecoratorMapper();
     }
 
@@ -36,6 +45,18 @@ import com.mercadopago.android.px.internal.viewmodel.mappers.BusinessModelMapper
     public void attachView(final ReviewAndConfirm.View view) {
         super.attachView(view);
         paymentRepository.attach(this);
+        resolveDynamicDialog(DynamicDialogConfiguration.DialogLocation.ENTER_REVIEW_AND_CONFIRM);
+    }
+
+    private void resolveDynamicDialog(@NonNull final DynamicDialogConfiguration.DialogLocation location) {
+        final DynamicDialogCreator.CheckoutData checkoutData =
+            new DynamicDialogCreator.CheckoutData(checkoutPreference, paymentRepository.getPaymentData());
+        if (dynamicDialogConfiguration.hasCreatorFor(location) &&
+            dynamicDialogConfiguration.getCreatorFor(location).shouldShowDialog(checkoutData)) {
+            getView().showDynamicDialog(
+                dynamicDialogConfiguration.getCreatorFor(location)
+                    .create(checkoutData));
+        }
     }
 
     @Override

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/components/ReviewAndConfirmContainer.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/components/ReviewAndConfirmContainer.java
@@ -2,6 +2,7 @@ package com.mercadopago.android.px.internal.features.review_and_confirm.componen
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import com.mercadopago.android.px.configuration.DynamicFragmentConfiguration;
 import com.mercadopago.android.px.configuration.ReviewAndConfirmConfiguration;
 import com.mercadopago.android.px.internal.features.review_and_confirm.models.ItemsModel;
 import com.mercadopago.android.px.internal.features.review_and_confirm.models.PaymentModel;
@@ -38,6 +39,7 @@ public class ReviewAndConfirmContainer extends Component<ReviewAndConfirmContain
         /* default */ @NonNull final PaymentModel paymentModel;
         /* default */ @NonNull final SummaryModel summaryModel;
         /* default */ @NonNull final ReviewAndConfirmConfiguration preferences;
+        /* default */ @NonNull final DynamicFragmentConfiguration dynamicFragments;
         /* default */ @NonNull final ItemsModel itemsModel;
         /* default */ @Nullable final TermsAndConditionsModel discountTermsAndConditionsModel;
 
@@ -45,6 +47,7 @@ public class ReviewAndConfirmContainer extends Component<ReviewAndConfirmContain
             @NonNull final PaymentModel paymentModel,
             @NonNull final SummaryModel summaryModel,
             @NonNull final ReviewAndConfirmConfiguration preferences,
+            @NonNull final DynamicFragmentConfiguration dynamicFragments,
             @NonNull final ItemsModel itemsModel,
             @Nullable final TermsAndConditionsModel discountTermsAndConditionsModel) {
 
@@ -52,6 +55,7 @@ public class ReviewAndConfirmContainer extends Component<ReviewAndConfirmContain
             this.paymentModel = paymentModel;
             this.summaryModel = summaryModel;
             this.preferences = preferences;
+            this.dynamicFragments = dynamicFragments;
             this.itemsModel = itemsModel;
             this.discountTermsAndConditionsModel = discountTermsAndConditionsModel;
         }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/components/ReviewAndConfirmRenderer.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/components/ReviewAndConfirmRenderer.java
@@ -50,10 +50,10 @@ public class ReviewAndConfirmRenderer extends Renderer<ReviewAndConfirmContainer
         final Session session = Session.getSession(context);
         final CheckoutPreference checkoutPreference =
             session.getConfigurationModule().getPaymentSettings().getCheckoutPreference();
-        final PaymentMethod paymentMethod =
-            session.getConfigurationModule().getUserSelectionRepository().getPaymentMethod();
+
+            ;
         final DynamicFragmentCreator.CheckoutData data =
-            new DynamicFragmentCreator.CheckoutData(checkoutPreference, paymentMethod);
+            new DynamicFragmentCreator.CheckoutData(checkoutPreference, session.getPaymentRepository().getPaymentData());
 
         if (component.props.dynamicFragments
             .hasCreatorFor(DynamicFragmentConfiguration.FragmentLocation.TOP_PAYMENT_METHOD_REVIEW_AND_CONFIRM)) {

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/components/ReviewAndConfirmRenderer.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/components/ReviewAndConfirmRenderer.java
@@ -19,7 +19,6 @@ import com.mercadopago.android.px.internal.view.ActionDispatcher;
 import com.mercadopago.android.px.internal.view.Renderer;
 import com.mercadopago.android.px.internal.view.RendererFactory;
 import com.mercadopago.android.px.internal.view.TermsAndConditionsComponent;
-import com.mercadopago.android.px.model.PaymentMethod;
 import com.mercadopago.android.px.preferences.CheckoutPreference;
 
 public class ReviewAndConfirmRenderer extends Renderer<ReviewAndConfirmContainer> {
@@ -61,10 +60,10 @@ public class ReviewAndConfirmRenderer extends Renderer<ReviewAndConfirmContainer
             final DynamicFragmentCreator fragmentCreator = component.props.dynamicFragments.getCreatorFor(
                 DynamicFragmentConfiguration.FragmentLocation.TOP_PAYMENT_METHOD_REVIEW_AND_CONFIRM);
 
-            if (fragmentCreator.shouldShowFragment(data)) {
+            if (fragmentCreator.shouldShowFragment(context, data)) {
                 FragmentUtil.addFragmentInside(linearLayout,
                     R.id.px_fragment_container_dynamic_top,
-                    fragmentCreator.create(data));
+                    fragmentCreator.create(context, data));
             }
         }
 
@@ -82,10 +81,10 @@ public class ReviewAndConfirmRenderer extends Renderer<ReviewAndConfirmContainer
             final DynamicFragmentCreator fragmentCreator = component.props.dynamicFragments.getCreatorFor(
                 DynamicFragmentConfiguration.FragmentLocation.BOTTOM_PAYMENT_METHOD_REVIEW_AND_CONFIRM);
 
-            if (fragmentCreator.shouldShowFragment(data)) {
+            if (fragmentCreator.shouldShowFragment(context, data)) {
                 FragmentUtil.addFragmentInside(linearLayout,
                     R.id.px_fragment_container_dynamic_bottom,
-                    fragmentCreator.create(data));
+                    fragmentCreator.create(context, data));
             }
         }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/components/ReviewAndConfirmRenderer.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/components/ReviewAndConfirmRenderer.java
@@ -7,6 +7,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import com.mercadopago.android.px.R;
+import com.mercadopago.android.px.configuration.DynamicFragmentConfiguration;
+import com.mercadopago.android.px.core.DynamicFragmentCreator;
+import com.mercadopago.android.px.internal.di.Session;
 import com.mercadopago.android.px.internal.features.review_and_confirm.components.actions.ChangePaymentMethodAction;
 import com.mercadopago.android.px.internal.features.review_and_confirm.components.items.ReviewItems;
 import com.mercadopago.android.px.internal.features.review_and_confirm.components.payment_method.PaymentMethodComponent;
@@ -16,6 +19,8 @@ import com.mercadopago.android.px.internal.view.ActionDispatcher;
 import com.mercadopago.android.px.internal.view.Renderer;
 import com.mercadopago.android.px.internal.view.RendererFactory;
 import com.mercadopago.android.px.internal.view.TermsAndConditionsComponent;
+import com.mercadopago.android.px.model.PaymentMethod;
+import com.mercadopago.android.px.preferences.CheckoutPreference;
 
 public class ReviewAndConfirmRenderer extends Renderer<ReviewAndConfirmContainer> {
 
@@ -42,12 +47,46 @@ public class ReviewAndConfirmRenderer extends Renderer<ReviewAndConfirmContainer
                 component.props.preferences.getTopFragment());
         }
 
+        final Session session = Session.getSession(context);
+        final CheckoutPreference checkoutPreference =
+            session.getConfigurationModule().getPaymentSettings().getCheckoutPreference();
+        final PaymentMethod paymentMethod =
+            session.getConfigurationModule().getUserSelectionRepository().getPaymentMethod();
+        final DynamicFragmentCreator.CheckoutData data =
+            new DynamicFragmentCreator.CheckoutData(checkoutPreference, paymentMethod);
+
+        if (component.props.dynamicFragments
+            .hasCreatorFor(DynamicFragmentConfiguration.FragmentLocation.TOP_PAYMENT_METHOD_REVIEW_AND_CONFIRM)) {
+
+            final DynamicFragmentCreator fragmentCreator = component.props.dynamicFragments.getCreatorFor(
+                DynamicFragmentConfiguration.FragmentLocation.TOP_PAYMENT_METHOD_REVIEW_AND_CONFIRM);
+
+            if (fragmentCreator.shouldShowFragment(data)) {
+                FragmentUtil.addFragmentInside(linearLayout,
+                    R.id.px_fragment_container_dynamic_top,
+                    fragmentCreator.create(data));
+            }
+        }
+
         addPaymentMethod(component.props.paymentModel, component.getDispatcher(), linearLayout);
 
         if (component.props.preferences.hasCustomBottomView()) {
             FragmentUtil.addFragmentInside(linearLayout,
                 R.id.px_fragment_container_bottom,
                 component.props.preferences.getBottomFragment());
+        }
+
+        if (component.props.dynamicFragments
+            .hasCreatorFor(DynamicFragmentConfiguration.FragmentLocation.BOTTOM_PAYMENT_METHOD_REVIEW_AND_CONFIRM)) {
+
+            final DynamicFragmentCreator fragmentCreator = component.props.dynamicFragments.getCreatorFor(
+                DynamicFragmentConfiguration.FragmentLocation.BOTTOM_PAYMENT_METHOD_REVIEW_AND_CONFIRM);
+
+            if (fragmentCreator.shouldShowFragment(data)) {
+                FragmentUtil.addFragmentInside(linearLayout,
+                    R.id.px_fragment_container_dynamic_bottom,
+                    fragmentCreator.create(data));
+            }
         }
 
         if (component.hasMercadoPagoTermsAndConditions()) {

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/util/FragmentUtil.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/util/FragmentUtil.java
@@ -27,16 +27,34 @@ public final class FragmentUtil {
     }
 
     public static void addFragmentInside(@NonNull final ViewGroup viewGroup,
+        @IdRes final int resId, @NonNull final Fragment fragment) {
+        if (viewGroup.getContext() instanceof AppCompatActivity) {
+            addFragmentInside(viewGroup, (AppCompatActivity) viewGroup.getContext(), resId, fragment);
+        } else {
+            throw new IllegalArgumentException("Container context is not a activity");
+        }
+    }
+
+    private static void addFragmentInside(@NonNull final ViewGroup viewGroup,
         @NonNull final AppCompatActivity context,
         @IdRes final int resId,
-        @NonNull String zClassFragmentName,
+        @NonNull final String zClassFragmentName,
         @Nullable final Bundle topArgs) {
+
+        final Fragment fragment = FragmentUtil.createInstance(zClassFragmentName);
+        fragment.setArguments(topArgs);
+
+        addFragmentInside(viewGroup, context, resId, fragment);
+    }
+
+    private static void addFragmentInside(@NonNull final ViewGroup viewGroup,
+        @NonNull final AppCompatActivity context,
+        @IdRes final int resId,
+        @NonNull final Fragment fragment) {
 
         final FrameLayout frameLayout = new FrameLayout(context);
         frameLayout.setId(resId);
         viewGroup.addView(frameLayout);
-        Fragment fragment = FragmentUtil.createInstance(zClassFragmentName);
-        fragment.setArguments(topArgs);
         context.getSupportFragmentManager()
             .beginTransaction()
             .replace(resId, fragment)
@@ -46,13 +64,13 @@ public final class FragmentUtil {
     @NonNull
     private static Fragment createInstance(@NonNull final String className) {
         try {
-            Class<Fragment> clazz = (Class<Fragment>) Class.forName(className);
+            final Class<Fragment> clazz = (Class<Fragment>) Class.forName(className);
             return clazz.newInstance();
-        } catch (ClassNotFoundException e) {
+        } catch (final ClassNotFoundException e) {
             e.printStackTrace();
-        } catch (IllegalAccessException e) {
+        } catch (final IllegalAccessException e) {
             e.printStackTrace();
-        } catch (InstantiationException e) {
+        } catch (final InstantiationException e) {
             e.printStackTrace();
         }
 

--- a/px-checkout/src/main/res/values/ids.xml
+++ b/px-checkout/src/main/res/values/ids.xml
@@ -2,6 +2,8 @@
 <resources>
     <item name="px_fragment_container_top" type="id"/>
     <item name="px_fragment_container_bottom" type="id"/>
+    <item name="px_fragment_container_dynamic_top" type="id"/>
+    <item name="px_fragment_container_dynamic_bottom" type="id"/>
     <item name="px_main_container" type="id"/>
     <item name="px_button_primary" type="id"/>
 </resources>


### PR DESCRIPTION
PANTALLA INTERMEDIA
• Soporte pantalla custom entre "Selección de medio de pago" y "Revisa y confirma". habilitar o no esta pantalla depende del medio de pago seleccionado.

CUSTOMIZAR RYC POST SELECCION
• Soporte para mostrar u ocultar cajitas de revisa y confirma dependiendo del medio de pago seleccionado.