### PR TITLE
[fix] Fixed PaymentMethodSearch tracking

### DIFF
--- a/CHANGELOG-v4.md
+++ b/CHANGELOG-v4.md
@@ -2,6 +2,7 @@
 _03_10_2018_
 
 * FIX - Show app bar when tap back from CVV screen.
+* FIX - Tracking of PaymentMethodSearchItem.
 
 ## VERSION 4.0.4
 _25_09_2018_

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/PaymentVaultPresenter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/PaymentVaultPresenter.java
@@ -395,11 +395,23 @@ public class PaymentVaultPresenter extends MvpPresenter<PaymentVaultView, Paymen
         if (selectedSearchItem != null) {
             getResourcesProvider()
                 .trackChildrenScreen(selectedSearchItem, configuration.getCheckoutPreference().getSite().getId());
-        } else if (paymentMethodSearch.hasSearchItems()) {
-            getResourcesProvider().trackChildrenScreen(paymentMethodSearch.getGroups().get(0),
-                configuration.getCheckoutPreference().getSite().getId());
         } else {
-            throw new IllegalStateException("No payment method available to track");
+            groupsRepository.getGroups().enqueue(new Callback<PaymentMethodSearch>() {
+                @Override
+                public void success(final PaymentMethodSearch paymentMethodSearch) {
+                    if (paymentMethodSearch.hasSearchItems()) {
+                        getResourcesProvider().trackChildrenScreen(paymentMethodSearch.getGroups().get(0),
+                            configuration.getCheckoutPreference().getSite().getId());
+                    } else {
+                        throw new IllegalStateException("No payment method available to track");
+                    }
+                }
+
+                @Override
+                public void failure(final ApiException apiException) {
+                    throw new IllegalStateException("No payment method available to track");
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Crasheaba cuando trackeabamos el paymentMethodSearchItem de grupos obtenido de PaymentMethodSearch y PaymentMethodSearch era nulo.
Ahora, antes de ejecutar el track, se va a buscar a GroupsRepository el PaymentMethodSearch. 
