### PR TITLE
[Feature] Wording configuration

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/configuration/AdvancedConfiguration.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/configuration/AdvancedConfiguration.java
@@ -20,7 +20,7 @@ public class AdvancedConfiguration implements Serializable {
     @NonNull private final ReviewAndConfirmConfiguration reviewAndConfirmConfiguration;
     @NonNull private final DynamicFragmentConfiguration dynamicFragmentConfiguration;
     @NonNull private final DynamicDialogConfiguration dynamicDialogConfiguration;
-    @NonNull private final DynamicLanguageConfiguration dynamicLanguageConfiguration;
+    @NonNull private final CustomStringConfiguration customStringConfiguration;
 
     /* default */ AdvancedConfiguration(final Builder builder) {
         bankDealsEnabled = builder.bankDealsEnabled;
@@ -29,7 +29,7 @@ public class AdvancedConfiguration implements Serializable {
         reviewAndConfirmConfiguration = builder.reviewAndConfirmConfiguration;
         dynamicFragmentConfiguration = builder.dynamicFragmentConfiguration;
         dynamicDialogConfiguration = builder.dynamicDialogConfiguration;
-        dynamicLanguageConfiguration = builder.dynamicLanguageConfiguration;
+        customStringConfiguration = builder.customStringConfiguration;
     }
 
     public boolean isBankDealsEnabled() {
@@ -61,8 +61,8 @@ public class AdvancedConfiguration implements Serializable {
     }
 
     @NonNull
-    public DynamicLanguageConfiguration getDynamicLanguageConfiguration(){
-        return dynamicLanguageConfiguration;
+    public CustomStringConfiguration getCustomStringConfiguration(){
+        return customStringConfiguration;
     }
 
     @SuppressWarnings("unused")
@@ -77,8 +77,8 @@ public class AdvancedConfiguration implements Serializable {
             new DynamicFragmentConfiguration.Builder().build();
         /* default */ @NonNull DynamicDialogConfiguration dynamicDialogConfiguration =
             new DynamicDialogConfiguration.Builder().build();
-        /* default */ @NonNull DynamicLanguageConfiguration dynamicLanguageConfiguration =
-            new DynamicLanguageConfiguration.Builder().build();
+        /* default */ @NonNull CustomStringConfiguration customStringConfiguration =
+            new CustomStringConfiguration.Builder().build();
 
 
 
@@ -163,14 +163,14 @@ public class AdvancedConfiguration implements Serializable {
 
         /**
          * Enable to preset configurations to configure specific wordings on
-         * several screen locations see {@link DynamicLanguageConfiguration.Builder}
+         * several screen locations see {@link CustomStringConfiguration.Builder}
          *
-         * @param dynamicLanguageConfiguration your custom configurations.
+         * @param customStringConfiguration your custom configurations.
          * @return builder to keep operating
          */
-        public Builder setDynamicLanguageConfiguration(
-            @NonNull final DynamicLanguageConfiguration dynamicLanguageConfiguration) {
-            this.dynamicLanguageConfiguration = dynamicLanguageConfiguration;
+        public Builder setCustomStringConfiguration(
+            @NonNull final CustomStringConfiguration customStringConfiguration) {
+            this.customStringConfiguration = customStringConfiguration;
             return this;
         }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/configuration/AdvancedConfiguration.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/configuration/AdvancedConfiguration.java
@@ -20,6 +20,7 @@ public class AdvancedConfiguration implements Serializable {
     @NonNull private final ReviewAndConfirmConfiguration reviewAndConfirmConfiguration;
     @NonNull private final DynamicFragmentConfiguration dynamicFragmentConfiguration;
     @NonNull private final DynamicDialogConfiguration dynamicDialogConfiguration;
+    @NonNull private final DynamicLanguageConfiguration dynamicLanguageConfiguration;
 
     /* default */ AdvancedConfiguration(final Builder builder) {
         bankDealsEnabled = builder.bankDealsEnabled;
@@ -28,6 +29,7 @@ public class AdvancedConfiguration implements Serializable {
         reviewAndConfirmConfiguration = builder.reviewAndConfirmConfiguration;
         dynamicFragmentConfiguration = builder.dynamicFragmentConfiguration;
         dynamicDialogConfiguration = builder.dynamicDialogConfiguration;
+        dynamicLanguageConfiguration = builder.dynamicLanguageConfiguration;
     }
 
     public boolean isBankDealsEnabled() {
@@ -58,6 +60,11 @@ public class AdvancedConfiguration implements Serializable {
         return reviewAndConfirmConfiguration;
     }
 
+    @NonNull
+    public DynamicLanguageConfiguration getDynamicLanguageConfiguration(){
+        return dynamicLanguageConfiguration;
+    }
+
     @SuppressWarnings("unused")
     public static class Builder {
         /* default */ boolean bankDealsEnabled = true;
@@ -70,6 +77,8 @@ public class AdvancedConfiguration implements Serializable {
             new DynamicFragmentConfiguration.Builder().build();
         /* default */ @NonNull DynamicDialogConfiguration dynamicDialogConfiguration =
             new DynamicDialogConfiguration.Builder().build();
+        /* default */ @NonNull DynamicLanguageConfiguration dynamicLanguageConfiguration =
+            new DynamicLanguageConfiguration.Builder().build();
 
 
 
@@ -151,6 +160,20 @@ public class AdvancedConfiguration implements Serializable {
             this.dynamicDialogConfiguration = dynamicDialogConfiguration;
             return this;
         }
+
+        /**
+         * Enable to preset configurations to configure specific wordings on
+         * several screen locations see {@link DynamicLanguageConfiguration.Builder}
+         *
+         * @param dynamicLanguageConfiguration your custom configurations.
+         * @return builder to keep operating
+         */
+        public Builder setDynamicLanguageConfiguration(
+            @NonNull final DynamicLanguageConfiguration dynamicLanguageConfiguration) {
+            this.dynamicLanguageConfiguration = dynamicLanguageConfiguration;
+            return this;
+        }
+
 
         public AdvancedConfiguration build() {
             return new AdvancedConfiguration(this);

--- a/px-checkout/src/main/java/com/mercadopago/android/px/configuration/CustomStringConfiguration.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/configuration/CustomStringConfiguration.java
@@ -35,6 +35,7 @@ public class CustomStringConfiguration {
          * @param mainVerbStringResId the string resource that will be used
          * @return builder to keep operating
          */
+        @SuppressWarnings("unused")
         public Builder setMainVerbStringResourceId(@StringRes final int mainVerbStringResId) {
             mainVerbStringResourceId = mainVerbStringResId;
             return this;

--- a/px-checkout/src/main/java/com/mercadopago/android/px/configuration/CustomStringConfiguration.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/configuration/CustomStringConfiguration.java
@@ -4,11 +4,11 @@ import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import com.mercadopago.android.px.R;
 
-public class DynamicLanguageConfiguration {
+public class CustomStringConfiguration {
 
     @StringRes private final int mainVerbStringResourceId;
 
-    /* default */ DynamicLanguageConfiguration(@NonNull final Builder builder) {
+    /* default */ CustomStringConfiguration(@NonNull final Builder builder) {
         this.mainVerbStringResourceId = builder.mainVerbStringResourceId;
     }
 
@@ -40,8 +40,8 @@ public class DynamicLanguageConfiguration {
             return this;
         }
 
-        public DynamicLanguageConfiguration build() {
-            return new DynamicLanguageConfiguration(this);
+        public CustomStringConfiguration build() {
+            return new CustomStringConfiguration(this);
         }
     }
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/configuration/DynamicLanguageConfiguration.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/configuration/DynamicLanguageConfiguration.java
@@ -1,0 +1,47 @@
+package com.mercadopago.android.px.configuration;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
+import com.mercadopago.android.px.R;
+
+public class DynamicLanguageConfiguration {
+
+    @StringRes private final int mainVerbStringResourceId;
+
+    /* default */ DynamicLanguageConfiguration(@NonNull final Builder builder) {
+        this.mainVerbStringResourceId = builder.mainVerbStringResourceId;
+    }
+
+    /**
+     * Let us know what the main verb is
+     *
+     * @return custom main verb or the default one
+     */
+    @StringRes
+    public int getMainVerbStringResourceId() {
+        return mainVerbStringResourceId;
+    }
+
+    public static class Builder {
+        /* default */ int mainVerbStringResourceId;
+
+        public Builder() {
+            this.mainVerbStringResourceId = R.string.px_main_verb;
+        }
+
+        /**
+         * Used to replace the main verb in Payment Methods screen
+         *
+         * @param mainVerbStringResId the string resource that will be used
+         * @return builder to keep operating
+         */
+        public Builder setMainVerbStringResourceId(@StringRes final int mainVerbStringResId) {
+            mainVerbStringResourceId = mainVerbStringResId;
+            return this;
+        }
+
+        public DynamicLanguageConfiguration build() {
+            return new DynamicLanguageConfiguration(this);
+        }
+    }
+}

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/di/Session.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/di/Session.java
@@ -3,6 +3,7 @@ package com.mercadopago.android.px.internal.di;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
 import com.mercadopago.android.px.configuration.PaymentConfiguration;
 import com.mercadopago.android.px.core.MercadoPagoCheckout;
 import com.mercadopago.android.px.core.PaymentProcessor;
@@ -181,6 +182,12 @@ public final class Session extends ApplicationModule
                     paymentSettings);
         }
         return discountRepository;
+    }
+
+    @StringRes
+    public int getMainVerb() {
+        return getConfigurationModule().getPaymentSettings().getAdvancedConfiguration()
+            .getCustomStringConfiguration().getMainVerbStringResourceId();
     }
 
     @NonNull

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/PaymentMethodsActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/PaymentMethodsActivity.java
@@ -104,9 +104,7 @@ public class PaymentMethodsActivity extends MercadoPagoBaseActivity implements P
         mBankDealsTextView = findViewById(R.id.mpsdkBankDeals);
         mTitle = findViewById(R.id.mpsdkToolbarTitle);
 
-        final String mainVerb =
-            getString(Session.getSession(this).getConfigurationModule().getPaymentSettings().getAdvancedConfiguration()
-                .getDynamicLanguageConfiguration().getMainVerbStringResourceId());
+        final String mainVerb = getString(Session.getSession(this).getMainVerb());
         mTitle.setText(getString(R.string.px_title_activity_payment_methods, mainVerb));
 
         setSupportActionBar(mToolbar);

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/PaymentMethodsActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/PaymentMethodsActivity.java
@@ -104,6 +104,11 @@ public class PaymentMethodsActivity extends MercadoPagoBaseActivity implements P
         mBankDealsTextView = findViewById(R.id.mpsdkBankDeals);
         mTitle = findViewById(R.id.mpsdkToolbarTitle);
 
+        final String mainVerb =
+            getString(Session.getSession(this).getConfigurationModule().getPaymentSettings().getAdvancedConfiguration()
+                .getDynamicLanguageConfiguration().getMainVerbStringResourceId());
+        mTitle.setText(getString(R.string.px_title_activity_payment_methods, mainVerb));
+
         setSupportActionBar(mToolbar);
         ActionBar supportActionBar = getSupportActionBar();
         supportActionBar.setDisplayShowTitleEnabled(false);

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/providers/PaymentVaultProviderImpl.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/providers/PaymentVaultProviderImpl.java
@@ -27,10 +27,7 @@ public class PaymentVaultProviderImpl implements PaymentVaultProvider {
 
     @Override
     public String getTitle() {
-        final String mainVerb =
-            context.getString(
-                Session.getSession(context).getConfigurationModule().getPaymentSettings().getAdvancedConfiguration()
-                    .getDynamicLanguageConfiguration().getMainVerbStringResourceId());
+        final String mainVerb = context.getString(Session.getSession(context).getMainVerb());
         return context.getString(R.string.px_title_activity_payment_vault, mainVerb);
     }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/providers/PaymentVaultProviderImpl.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/providers/PaymentVaultProviderImpl.java
@@ -11,7 +11,6 @@ import com.mercadopago.android.px.model.PaymentMethodSearch;
 import com.mercadopago.android.px.model.PaymentMethodSearchItem;
 import com.mercadopago.android.px.tracking.internal.MPTracker;
 
-
 public class PaymentVaultProviderImpl implements PaymentVaultProvider {
 
     private final Context context;
@@ -28,7 +27,11 @@ public class PaymentVaultProviderImpl implements PaymentVaultProvider {
 
     @Override
     public String getTitle() {
-        return context.getString(R.string.px_title_activity_payment_vault);
+        final String mainVerb =
+            context.getString(
+                Session.getSession(context).getConfigurationModule().getPaymentSettings().getAdvancedConfiguration()
+                    .getDynamicLanguageConfiguration().getMainVerbStringResourceId());
+        return context.getString(R.string.px_title_activity_payment_vault, mainVerb);
     }
 
     @Override

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/AmountView.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/AmountView.java
@@ -133,7 +133,7 @@ public class AmountView extends LinearLayoutCompat {
     private void show(@NonNull final BigDecimal totalAmount, @NonNull final Site site) {
         configureViewsVisibilityDefault();
         final String mainVerb = getContext().getString(Session.getSession(getContext()).getMainVerb());
-        amountDescription.setText(getContext().getString(R.string.px_title_activity_payment_vault, mainVerb));
+        amountDescription.setText(getContext().getString(R.string.px_total_to_pay, mainVerb));
         amountDescription.setTextColor(getResources().getColor(R.color.px_form_text));
         showEffectiveAmount(totalAmount, site);
     }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/AmountView.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/AmountView.java
@@ -11,6 +11,7 @@ import android.view.View;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import com.mercadopago.android.px.R;
+import com.mercadopago.android.px.internal.di.Session;
 import com.mercadopago.android.px.internal.repository.DiscountRepository;
 import com.mercadopago.android.px.internal.util.textformatter.TextFormatter;
 import com.mercadopago.android.px.model.Campaign;
@@ -131,7 +132,10 @@ public class AmountView extends LinearLayoutCompat {
 
     private void show(@NonNull final BigDecimal totalAmount, @NonNull final Site site) {
         configureViewsVisibilityDefault();
-        amountDescription.setText(R.string.px_total_to_pay);
+        final String mainVerb =
+            getContext().getString(Session.getSession(getContext()).getConfigurationModule().getPaymentSettings()
+                .getAdvancedConfiguration().getDynamicLanguageConfiguration().getMainVerbStringResourceId());
+        amountDescription.setText(getContext().getString(R.string.px_title_activity_payment_vault, mainVerb));
         amountDescription.setTextColor(getResources().getColor(R.color.px_form_text));
         showEffectiveAmount(totalAmount, site);
     }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/AmountView.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/AmountView.java
@@ -132,9 +132,7 @@ public class AmountView extends LinearLayoutCompat {
 
     private void show(@NonNull final BigDecimal totalAmount, @NonNull final Site site) {
         configureViewsVisibilityDefault();
-        final String mainVerb =
-            getContext().getString(Session.getSession(getContext()).getConfigurationModule().getPaymentSettings()
-                .getAdvancedConfiguration().getDynamicLanguageConfiguration().getMainVerbStringResourceId());
+        final String mainVerb = getContext().getString(Session.getSession(getContext()).getMainVerb());
         amountDescription.setText(getContext().getString(R.string.px_title_activity_payment_vault, mainVerb));
         amountDescription.setTextColor(getResources().getColor(R.color.px_form_text));
         showEffectiveAmount(totalAmount, site);

--- a/px-checkout/src/main/res/values-es/strings.xml
+++ b/px-checkout/src/main/res/values-es/strings.xml
@@ -20,12 +20,13 @@
     <string name="bank_deal_details_date_format">Hasta el %s</string>
 
     <!-- Payment Methods -->
-    <string name="px_title_activity_payment_methods">¿Cómo quieres pagar?</string>
+    <string name="px_title_activity_payment_methods">¿Cómo quieres %1$s?</string>
+    <string name="px_main_verb">pagar</string>
 
     <!-- Vault -->
     <string name="px_last_digits_label">Terminada en</string>
     <string name="px_confirm">Confirmar</string>
-    <string name="px_title_activity_payment_vault">¿Cómo quieres pagar?</string>
+    <string name="px_title_activity_payment_vault">¿Cómo quieres %1$s?</string>
     <string name="px_no_payment_methods_found">No hay medios de pago disponibles</string>
 
     <!-- Issuers -->
@@ -230,7 +231,7 @@
     <string name="px_something_went_wrong">¡Uy! Algo salió mal…</string>
     <string name="px_we_apply_the_best_available_discount">Los descuentos no son acumulables. Te damos el más alto para este pago.</string>
     <string name="px_max_coupon_amount">Tope de descuento: %1$s</string>
-    <string name="px_total_to_pay">Total a pagar</string>
+    <string name="px_total_to_pay">Total a %1$s</string>
     <string name="px_enter_coupon_code">Ingresa tu cupón de descuento</string>
     <string name="px_enter_coupon_code_title">Ingresa tu cupón</string>
     <string name="px_with_max_coupon_amount">Con tope de descuento</string>

--- a/px-checkout/src/main/res/values-pt/strings.xml
+++ b/px-checkout/src/main/res/values-pt/strings.xml
@@ -20,12 +20,13 @@
     <string name="bank_deal_details_date_format">Até %s</string>
 
     <!-- Payment Methods -->
-    <string name="px_title_activity_payment_methods">Como você prefere pagar?</string>
+    <string name="px_title_activity_payment_methods">Como você prefere %1$s?</string>
+    <string name="px_main_verb">pagar</string>
 
     <!-- Vault -->
     <string name="px_last_digits_label">Terminado em</string>
     <string name="px_confirm">Confirmar</string>
-    <string name="px_title_activity_payment_vault">Como você prefere pagar?</string>
+    <string name="px_title_activity_payment_vault">Como você prefere %1$s?</string>
     <string name="px_no_payment_methods_found">Não há meios de pagamento disponíveis</string>
 
     <!-- Issuers -->
@@ -231,7 +232,7 @@
     <string name="px_something_went_wrong">Ops! Algo deu errado…</string>
     <string name="px_we_apply_the_best_available_discount">Os descontos não são acumulativos. Aplicamos o mais alto para este pagamento.</string>
     <string name="px_max_coupon_amount">Limite de descontos: %1$s</string>
-    <string name="px_total_to_pay">Total a pagar</string>
+    <string name="px_total_to_pay">Total a %1$s</string>
     <string name="px_enter_coupon_code">Digite seu cupom de desconto</string>
     <string name="px_enter_coupon_code_title">Adicione o seu cupom</string>
     <string name="px_with_max_coupon_amount">Com limite de desconto</string>

--- a/px-checkout/src/main/res/values/strings.xml
+++ b/px-checkout/src/main/res/values/strings.xml
@@ -23,13 +23,13 @@
     <string name="bank_deal_details_date_format">Up to %s</string>
 
     <!-- Payment Methods -->
-    <string name="px_title_activity_payment_methods">How do you want to pay?</string>
-
+    <string name="px_title_activity_payment_methods">How do you want to %1$s?</string>
+    <string name="px_main_verb">pay</string>
 
     <!-- Vault -->
     <string name="px_last_digits_label">Ending in</string>
     <string name="px_confirm">Confirm</string>
-    <string name="px_title_activity_payment_vault">How do you want to pay?</string>
+    <string name="px_title_activity_payment_vault">How do you want to %1$s?</string>
     <string name="px_no_payment_methods_found">There are no available payment methods</string>
 
     <!-- Issuers -->
@@ -245,7 +245,7 @@
     <string name="px_we_apply_the_best_available_discount">Discounts are not cumulative. We apply the best available discount</string>
     <string name="px_max_coupon_amount">Discount limit: %1$s</string>
     <string name="px_with_max_coupon_amount">With max coupon amount</string>
-    <string name="px_total_to_pay">Total to pay</string>
+    <string name="px_total_to_pay">Total to %1$s</string>
     <string name="px_enter_coupon_code">Enter your discount coupon</string>
     <string name="px_enter_coupon_code_title">Enter your coupon</string>
     <string name="px_always_on_discount_detail">With each payment to this brand you will consume the discounts until you reach the limit.</string>


### PR DESCRIPTION
Se agrega la posibilidad de modificar los el verbo principal de la pantalla de medios de pago, pudiendo enviar un String Rrsource Id que contenga el verbo a reemplazar (por ejemplo: "pagar" por "ingresar")

## Motivación y Contexto
Necesitamos poder modificar los textos de la pantalla de medios de pago

## Descripción
Se spliteó el string resource utilizado para el titulo de la pantalla y tambien el de pie de pantalla (texto de "Total to pay") para que este ultimo verbo sea variable

## Cómo probarlo
Luego de iniciar checkout (luego de llamar a startPayment) se debe setear un InternalConfiguration a travez de la Session

## Screenshots
<!--- Para bug fixes: Incluir screenshots o videos del antes y después -->
<!--- Para nuevos features: Incluir screenshots o videos de la nueva UI -->

## Tipo de cambio (para el release manager)
- No breaking change