### PR TITLE
[FIX] Card association crash on congrats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## VERSION 4.3.2
+_30_11_2018_
+
+* FIX - Crash on Card Association congrats
+
 ## VERSION 4.3.1
 _21_11_2018_
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.daemon=true
 #org.gradle.configureondemand=true
 #org.gradle.jvmargs=-Xmx1024m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # Current lib version
-version_to_deploy=4.3.1
+version_to_deploy=4.3.2
 # Compile versions
 build_tools_version=27.0.2
 min_api_level=16

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/card_association_result/CardAssociationResultErrorActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/card_association_result/CardAssociationResultErrorActivity.java
@@ -13,7 +13,7 @@ import com.mercadopago.android.px.internal.features.guessing_card.GuessingCardAc
 import com.mercadopago.android.px.internal.util.StatusBarDecorator;
 import com.mercadopago.android.px.tracking.internal.MPTracker;
 import com.mercadopago.android.px.tracking.internal.utils.TrackingUtil;
-import java.util.Collections;
+import java.util.HashMap;
 
 public class CardAssociationResultErrorActivity extends AppCompatActivity {
     public static final String PARAM_ACCESS_TOKEN = "accessToken";
@@ -80,6 +80,6 @@ public class CardAssociationResultErrorActivity extends AppCompatActivity {
 
     private void trackScreen() {
         MPTracker.getInstance().trackView(TrackingUtil.SCREEN_ID_CARD_ASSOCIATION_ERROR,
-            Collections.<String, Object>emptyMap());
+            new HashMap<String, Object>());
     }
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/card_association_result/CardAssociationResultSuccessActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/card_association_result/CardAssociationResultSuccessActivity.java
@@ -12,7 +12,7 @@ import com.mercadopago.android.px.R;
 import com.mercadopago.android.px.internal.util.StatusBarDecorator;
 import com.mercadopago.android.px.tracking.internal.MPTracker;
 import com.mercadopago.android.px.tracking.internal.utils.TrackingUtil;
-import java.util.Collections;
+import java.util.HashMap;
 
 public class CardAssociationResultSuccessActivity extends AppCompatActivity {
 
@@ -45,6 +45,6 @@ public class CardAssociationResultSuccessActivity extends AppCompatActivity {
 
     private void trackScreen() {
         MPTracker.getInstance()
-            .trackView(TrackingUtil.SCREEN_ID_CARD_ASSOCIATION_SUCCESS, Collections.<String, Object>emptyMap());
+            .trackView(TrackingUtil.SCREEN_ID_CARD_ASSOCIATION_SUCCESS, new HashMap<String, Object>());
     }
 }


### PR DESCRIPTION
## Motivación y Contexto
Resuelve el crash que se genera al enviar un map inmutable en el tracking de la pantalla de congrats de asociación de tarjeta

## Descripción
Se cambio de inmutable a mutable
