### PR TITLE
[Fix] Removed code coverage for release

### DIFF
--- a/gradle/base_android_lib.gradle
+++ b/gradle/base_android_lib.gradle
@@ -36,9 +36,6 @@ android {
     }
 
     buildTypes {
-        release {
-            testCoverageEnabled true
-        }
         debug {
             testCoverageEnabled true
         }


### PR DESCRIPTION
Se elimina el code coverage para release dado que hacía romper los tests de regression.
