### PR TITLE
[enhancement] better deploy scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,7 @@ before_script:
   - adb shell setprop dalvik.vm.dexopt-flags v=n,o=v
 
 script:
-  - ./gradlew :px-checkout:lint
-  - ./gradlew :px-checkout:jacocoTestReport
+  - ./gradlew :px-checkout:lint && ./gradlew :px-checkout:jacocoTestReport && ./scripts/cd_script.sh
 
 after_success:
 - pip install --user codecov

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ buildscript {
         // If we upload to 3.1.4 then you will be asked to set builtools in 27.0.3
         // If we upload buildtools to 27.0.3 we will have to upload appcompat to 27.0.3 and
         // we can't do so because release won't work on MercadoLibre's App.
-        classpath 'org.jacoco:org.jacoco.core:0.8.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath 'org.jacoco:org.jacoco.core:0.8.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.monits:static-code-analysis-plugin:2.6.7'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.3'

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.daemon=true
 #org.gradle.configureondemand=true
 #org.gradle.jvmargs=-Xmx1024m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # Current lib version
-version_to_deploy=4.3.3
+version_to_deploy=TEST-4.3.3
 # Compile versions
 build_tools_version=27.0.2
 min_api_level=16

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.daemon=true
 #org.gradle.configureondemand=true
 #org.gradle.jvmargs=-Xmx1024m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # Current lib version
-version_to_deploy=TEST-4.3.3
+version_to_deploy=4.3.3
 # Compile versions
 build_tools_version=27.0.2
 min_api_level=16

--- a/gradle/deploy_base.gradle
+++ b/gradle/deploy_base.gradle
@@ -114,8 +114,8 @@ install {
 
 bintray {
     version = versionToDeploy
-    user = localProperties.getProperty("bintray.user", "")
-    key = localProperties.getProperty("bintray.apikey", "")
+    user = "$System.env.BINTRAY_USER"
+    key = "$System.env.BINTRAY_API_KEY"
 
     override = true
 

--- a/px-checkout/src/androidTest/java/com/mercadopago/android/px/model/CardTokenTest.java
+++ b/px-checkout/src/androidTest/java/com/mercadopago/android/px/model/CardTokenTest.java
@@ -223,7 +223,7 @@ public class CardTokenTest extends BaseTest<CheckoutActivity> {
 
     public void testExpiryDateShortYear() {
         CardToken cardToken = StaticMock.getCardToken();
-        cardToken.setExpirationYear(18);
+        cardToken.setExpirationYear(23);
 
         assertTrue(cardToken.validateExpiryDate());
     }

--- a/scripts/cd_script.sh
+++ b/scripts/cd_script.sh
@@ -25,10 +25,10 @@ then
 	. gradle.properties
 	TMP_BRANCH="deploy_branch_tag_$version_to_deploy"
 	## Tag and push
-	git checkout -b $TMP_BRANCH && git push origin $TMP_BRANCH && git tag -a $version_to_deploy -m "travis deployed version $version_to_deploy" && git push origin $TMP_BRANCH --follow-tags && gradlew -Pproduction publishAar -q
+	git checkout -b $TMP_BRANCH && git push origin $TMP_BRANCH && git tag -a $version_to_deploy -m "travis deployed version $version_to_deploy" && git push origin $TMP_BRANCH --follow-tags && ./gradlew -Pproduction publishAar -q
 fi
 
 if [ "$DEPLOY_COMMAND" != "$LAST_GIT_COMMIT" ]
 then
-	gradlew publishAar -q
+	./gradlew publishAar -q
 fi

--- a/scripts/cd_script.sh
+++ b/scripts/cd_script.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+DEPLOY_COMMAND="[ci deploy]"
+
+# get current directory name
+BASEDIR=`dirname $0`
+# assumes that next gradle commands will execute in basedir/..
+# put current dir in the stack and move current working dir to basedir/..
+# stack -> ./scripts ---- /.../.../px-android/
+command pushd "$BASEDIR/.." > /dev/null
+
+echo "Evaluating if it was deploy command $DEPLOY_COMMAND"
+
+# Get last commit message in a variable
+LAST_GIT_COMMIT=$(git log -1 --pretty=%B)
+
+echo "last git commit has $LAST_GIT_COMMIT"
+
+
+if [ "$DEPLOY_COMMAND" == "$LAST_GIT_COMMIT" ]
+then
+	#git tag -a
+	#gradlew publishAar -q
+	# Load properties
+	. gradle.properties
+	TMP_BRANCH="deploy_branch_tag_$version_to_deploy"
+	## Tag and push
+	git checkout -b $TMP_BRANCH && git push origin $TMP_BRANCH && git tag -a $version_to_deploy -m "travis deployed version $version_to_deploy" && git push origin $TMP_BRANCH --follow-tags && gradlew -Pproduction publishAar -q
+fi
+
+if [ "$DEPLOY_COMMAND" != "$LAST_GIT_COMMIT" ]
+then
+	gradlew publishAar -q
+fi

--- a/scripts/cd_script.sh
+++ b/scripts/cd_script.sh
@@ -11,13 +11,13 @@ command pushd "$BASEDIR/.." > /dev/null
 
 echo "Evaluating if it was deploy command $DEPLOY_COMMAND"
 
-# Get last commit message in a variable
-LAST_GIT_COMMIT=$(git log -1 --pretty=%B)
+# Get last 2 commit messages (1 is the merge, second last real commit) in a variable
+LAST_GIT_COMMIT=$(git log -2 --pretty=%B)
 
 echo "last git commit has $LAST_GIT_COMMIT"
 
 
-if [ "$DEPLOY_COMMAND" == "$LAST_GIT_COMMIT" ]
+if [ "$LAST_GIT_COMMIT" == *"$DEPLOY_COMMAND"* ]
 then
 	#git tag -a
 	#gradlew publishAar -q

--- a/scripts/cd_script.sh
+++ b/scripts/cd_script.sh
@@ -17,7 +17,7 @@ LAST_GIT_COMMIT=$(git log -2 --pretty=%B)
 echo "last git commit has $LAST_GIT_COMMIT"
 
 
-if [ "$LAST_GIT_COMMIT" == *"$DEPLOY_COMMAND"* ]
+if [[ "$LAST_GIT_COMMIT" == *"$DEPLOY_COMMAND"* ]]
 then
 	#git tag -a
 	#gradlew publishAar -q
@@ -28,7 +28,7 @@ then
 	git checkout -b $TMP_BRANCH && git push origin $TMP_BRANCH && git tag -a $version_to_deploy -m "travis deployed version $version_to_deploy" && git push origin $TMP_BRANCH --follow-tags && ./gradlew -Pproduction publishAar -q
 fi
 
-if [ "$DEPLOY_COMMAND" != "$LAST_GIT_COMMIT" ]
+if [[ "$LAST_GIT_COMMIT" !=  *"$DEPLOY_COMMAND"* ]]
 then
 	./gradlew publishAar -q
 fi


### PR DESCRIPTION
## Importante
Empieza a funcionar el comando "[ci deploy]" (como en plugin de meli) dentro del commit. Si tiene ese mensaje dentro del commit message va a generar un build y deploy en producción, previo taggeo.
A partir de ahora todos los PRs generan versiones experimentales. Para buscar el número ir al log de travis.

Por último, no es más necesario ponerle publish en bintray para terminar de publicar.


- Updated jacoco version
- Updated jfrog bintray gradle plugin
- added script for .travis
