### PR TITLE
[fix] fallback fix when lose reference to payment processor

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/PaymentSettingService.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/PaymentSettingService.java
@@ -103,6 +103,12 @@ public class PaymentSettingService implements PaymentSettingRepository {
     @NonNull
     @Override
     public PaymentConfiguration getPaymentConfiguration() {
+        if (paymentConfiguration == null) {
+            // Hotfix - We will persist the paymentConfiguration instance on disk
+            // in future releases
+            // TODO: add disk cache for payment processor.
+            return new MercadoPagoPaymentConfiguration();
+        }
         return paymentConfiguration;
     }
 


### PR DESCRIPTION
NPE caused by losing reference to payment configuration.

By default we will enfonce our own payment config to avoid NPE.

## Reported by: @bolds07 
## Issue: https://github.com/mercadopago/px-android/issues/1481