### PR TITLE
[Fix] One Tap MLB - "CFT: null"

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/util/textformatter/CFTFormatter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/util/textformatter/CFTFormatter.java
@@ -6,6 +6,7 @@ import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import com.mercadolibre.android.ui.font.Font;
 import com.mercadopago.android.px.R;
+import com.mercadopago.android.px.internal.util.TextUtil;
 import com.mercadopago.android.px.internal.util.ViewUtils;
 import com.mercadopago.android.px.model.PayerCost;
 
@@ -36,7 +37,9 @@ public class CFTFormatter extends ChainFormatter {
 
     @Override
     protected Spannable apply(@NonNull final CharSequence amount) {
-
+        if (TextUtil.isEmpty(amount)) {
+            return spannableStringBuilder;
+        }
         final int initialIndex = spannableStringBuilder.length();
         final String cftDescription = context.getString(R.string.px_installments_cft, amount);
         final String separator = " ";


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
<!--- ¿Por qué este cambio es requerido? ¿Qué problema resuelve? -->
El CFT Formatter no contempla el caso en que el CFT sea null (por ejemplo en One tap MLB).

## Descripción
<!--- Describir los cambios en detalle -->
- Ahora si el porcentaje CFT es null o vacío no se muestra dicha descripción.

## Cómo probarlo
<!--- Para bug fixes: Describir cómo reproducir el comportamiento que generaba el bug -->
<!--- Para nuevos features: Se debe agregar el caso de uso a la app de ejemplos, y aquí se debe describir qué función de la app de ejemplos probar -->
Iniciar el checkout con las [credenciales correspondientes de MLB sección Config](https://docs.google.com/spreadsheets/d/1EI5HdqQ_Oi8gG_YHFU9rXebdMujclcoP10QqfjhE3HU/edit#gid=1230229952).
## Screenshots
<!--- Para bug fixes: Incluir screenshots o videos del antes y después -->
<!--- Para nuevos features: Incluir screenshots o videos de la nueva UI -->
### Antes
![elo](https://user-images.githubusercontent.com/7771294/52734655-89875300-2fa4-11e9-9c17-66fe627f3d2f.png)

### Después
![elo despues](https://user-images.githubusercontent.com/7771294/52734663-8f7d3400-2fa4-11e9-8f61-24e27e990d23.png)

## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
