### PR TITLE
[fix] clear user selection on change payment method

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmPresenter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmPresenter.java
@@ -83,6 +83,7 @@ import java.util.Set;
     @Override
     public void changePaymentMethod() {
         ChangePaymentMethodEvent.create().track();
+        removeUserSelection();
         getView().finishAndChangePaymentMethod();
     }
 


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
<!--- ¿Por qué este cambio es requerido? ¿Qué problema resuelve? -->
En descuentos por medio de pago, al elegir en en la pantalla de grupos el medio de pago que tiene descuentos y luego en la pantalla de revisa y confirma se elige cambiar el medio de pago, figura en la pantalla de grupos el descuento a nivel general mostrandolo en el footer de amount.
## Descripción
<!--- Describir los cambios en detalle -->
- Se hace un reset de UserSelectionRepository al momento de elegir cambiar el medio de pago.
## Cómo probarlo
<!--- Para bug fixes: Describir cómo reproducir el comportamiento que generaba el bug -->
<!--- Para nuevos features: Se debe agregar el caso de uso a la app de ejemplos, y aquí se debe describir qué función de la app de ejemplos probar -->
- Con un collector que tenga descuentos en un medio de pago determinado, elegir dicho medio de pago
- En la pantalla de revisa y confirma, elegir cambiar medio de pago.
## Screenshots
<!--- Para bug fixes: Incluir screenshots o videos del antes y después -->
<!--- Para nuevos features: Incluir screenshots o videos de la nueva UI -->

## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
