### PR TITLE
[enhancement] Sold out discount color

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/AmountDescriptorView.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/AmountDescriptorView.java
@@ -59,7 +59,7 @@ public class AmountDescriptorView extends LinearLayout {
     public void update(@NonNull final AmountDescriptorView.Model model) {
         updateLeftLabel(model);
         updateRightLabel(model);
-        updateDrawable(model.detailDrawable);
+        updateDrawable(model.detailDrawable, model.detailDrawableColor);
         updateTextColor(model.detailColor);
         listenerEnabled = model.listenerEnabled;
     }
@@ -113,11 +113,16 @@ public class AmountDescriptorView extends LinearLayout {
         rightLabel.setTextColor(detailColor.getColor(getContext()));
     }
 
-    private void updateDrawable(@Nullable final IDetailDrawable detailDrawable) {
+    private void updateDrawable(@Nullable final IDetailDrawable detailDrawable,
+        @Nullable final IDetailColor detailColor) {
         if (detailDrawable != null) {
             imageView.setImageDrawable(detailDrawable.getDrawable(getContext()));
         } else {
             imageView.setVisibility(INVISIBLE);
+        }
+
+        if (detailColor != null) {
+            imageView.setColorFilter(detailColor.getColor(getContext()));
         }
     }
 
@@ -134,6 +139,7 @@ public class AmountDescriptorView extends LinearLayout {
         /* default */ @NonNull final ILocalizedCharSequence right;
         /* default */ @NonNull final IDetailColor detailColor;
         /* default */ @Nullable IDetailDrawable detailDrawable;
+        /* default */ @Nullable IDetailColor detailDrawableColor;
         /* default */ boolean listenerEnabled = false;
 
         public Model(@NonNull final ILocalizedCharSequence left, @NonNull final ILocalizedCharSequence right,
@@ -151,6 +157,14 @@ public class AmountDescriptorView extends LinearLayout {
 
         public AmountDescriptorView.Model setDetailDrawable(@Nullable final IDetailDrawable detailDrawable) {
             this.detailDrawable = detailDrawable;
+            detailDrawableColor = null;
+            return this;
+        }
+
+        public AmountDescriptorView.Model setDetailDrawable(@Nullable final IDetailDrawable detailDrawable,
+            @Nullable final IDetailColor detailDrawableColor) {
+            this.detailDrawable = detailDrawable;
+            this.detailDrawableColor = detailDrawableColor;
             return this;
         }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/SummaryDetailDescriptorFactory.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/SummaryDetailDescriptorFactory.java
@@ -42,7 +42,7 @@ public class SummaryDetailDescriptorFactory {
             list.add(new AmountDescriptorView.Model(new ItemLocalized(),
                 new AmountLocalized(checkoutPreference.getTotalAmount(),
                     checkoutPreference.getSite().getCurrencyId()), new ItemDetailColor()));
-            list.add(new AmountDescriptorView.Model(new SoldOutDiscountLocalized(), new ItemDetailColor())
+            list.add(new AmountDescriptorView.Model(new SoldOutDiscountLocalized(), new DiscountDetailColor())
                 .setDetailDrawable(new DiscountDetailDrawable())
                 .enableListener());
         }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/SummaryDetailDescriptorFactory.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/SummaryDetailDescriptorFactory.java
@@ -8,6 +8,7 @@ import com.mercadopago.android.px.internal.viewmodel.DiscountDetailColor;
 import com.mercadopago.android.px.internal.viewmodel.DiscountDetailDrawable;
 import com.mercadopago.android.px.internal.viewmodel.ItemDetailColor;
 import com.mercadopago.android.px.internal.viewmodel.ItemLocalized;
+import com.mercadopago.android.px.internal.viewmodel.SoldOutDiscountDetailColor;
 import com.mercadopago.android.px.internal.viewmodel.SoldOutDiscountLocalized;
 import com.mercadopago.android.px.model.DiscountConfigurationModel;
 import com.mercadopago.android.px.preferences.CheckoutPreference;
@@ -42,8 +43,8 @@ public class SummaryDetailDescriptorFactory {
             list.add(new AmountDescriptorView.Model(new ItemLocalized(),
                 new AmountLocalized(checkoutPreference.getTotalAmount(),
                     checkoutPreference.getSite().getCurrencyId()), new ItemDetailColor()));
-            list.add(new AmountDescriptorView.Model(new SoldOutDiscountLocalized(), new DiscountDetailColor())
-                .setDetailDrawable(new DiscountDetailDrawable())
+            list.add(new AmountDescriptorView.Model(new SoldOutDiscountLocalized(), new SoldOutDiscountDetailColor())
+                .setDetailDrawable(new DiscountDetailDrawable(), new SoldOutDiscountDetailColor())
                 .enableListener());
         }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/viewmodel/SoldOutDiscountDetailColor.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/viewmodel/SoldOutDiscountDetailColor.java
@@ -1,0 +1,14 @@
+package com.mercadopago.android.px.internal.viewmodel;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
+import com.mercadopago.android.px.R;
+
+public class SoldOutDiscountDetailColor implements IDetailColor {
+
+    @Override
+    public int getColor(@NonNull final Context context) {
+        return ContextCompat.getColor(context, R.color.px_expressCheckoutSoldOutDiscount);
+    }
+}

--- a/px-checkout/src/main/res/values/colors.xml
+++ b/px-checkout/src/main/res/values/colors.xml
@@ -167,10 +167,10 @@
     <color name="px_expressCheckoutTextColor">@color/px_white</color>
     <color name="px_expressCheckoutTextColorDiscount">@color/px_white</color>
     <color name="px_expressCheckoutImageDiscount">@color/px_white</color>
+    <color name="px_expressCheckoutSoldOutDiscount">@color/px_white</color>
     <color name="px_expressCheckoutTextColorDetail">#B3FFFFFF</color>
     <color name="px_expressCheckoutSeparatorLine">#19000000</color>
     <color name="px_expressCheckoutScrollIndicatorColor">@color/px_expressCheckoutSeparatorLine</color>
     <color name="px_expressCheckoutChangePaymentMethodColor">#ffeae8e8</color>
     <color name="px_expressCheckoutInstallmentTitle">#73000000</color>
-
 </resources>


### PR DESCRIPTION
Se modifico la lógica de aplicación del color en la row de sold out discount de Summary View. 

En MP tiene que tener el mismo color que la row del descuento, mientras que en Meli tiene que tener el mismo color que el texto que dice "Tu compra".
![Screenshot_1552416024](https://user-images.githubusercontent.com/4195740/54230562-67bab680-44e5-11e9-84b6-2c74940d5ad9.png)
