### PR TITLE
[fix] split payment congrats amount

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/PaymentMethodComponent.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/PaymentMethodComponent.java
@@ -47,7 +47,7 @@ public class PaymentMethodComponent extends CompactComponent<PaymentMethodCompon
             @NonNull final String currencyId,
             @NonNull final String statementDescription) {
             final TotalAmount.Props totalAmountProps =
-                new TotalAmount.Props(currencyId, paymentData.getTransactionAmount(),
+                new TotalAmount.Props(currencyId, paymentData.getRawAmount(),
                     paymentData.getPayerCost());
 
             return new PaymentMethodComponent.PaymentMethodProps(paymentData.getPaymentMethod(),


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
<!--- ¿Por qué este cambio es requerido? ¿Qué problema resuelve? -->
En la pantalla de congrats se está mostrando el transactionAmount que es el mismo en todos los payment data, hay que usar rawAmount.
## Descripción
<!--- Describir los cambios en detalle -->
- Cambio transactionAmount por rawAmount en el armado de la pantalla de congrats
## Cómo probarlo
<!--- Para bug fixes: Describir cómo reproducir el comportamiento que generaba el bug -->
<!--- Para nuevos features: Se debe agregar el caso de uso a la app de ejemplos, y aquí se debe describir qué función de la app de ejemplos probar -->
- Generar un pago exitoso con split payment
## Screenshots
<!--- Para bug fixes: Incluir screenshots o videos del antes y después -->
<!--- Para nuevos features: Incluir screenshots o videos de la nueva UI -->

## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
