### PR TITLE
Fetch and select default installment one step before to avoid InstallmentsActivity blank screen

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/di/Session.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/di/Session.java
@@ -31,6 +31,7 @@ import com.mercadopago.android.px.internal.datasource.cache.GroupsCache;
 import com.mercadopago.android.px.internal.datasource.cache.GroupsCacheCoordinator;
 import com.mercadopago.android.px.internal.datasource.cache.GroupsDiskCache;
 import com.mercadopago.android.px.internal.datasource.cache.GroupsMemCache;
+import com.mercadopago.android.px.internal.features.guessing_card.IssuersSolver;
 import com.mercadopago.android.px.internal.features.installments.PayerCostSolver;
 import com.mercadopago.android.px.internal.repository.AmountConfigurationRepository;
 import com.mercadopago.android.px.internal.repository.AmountRepository;
@@ -340,6 +341,14 @@ public final class Session extends ApplicationModule
             issuersRepository = new IssuersServiceImp(issuersService, getConfigurationModule().getPaymentSettings());
         }
         return issuersRepository;
+    }
+
+    @NonNull
+    public IssuersSolver provideIssuersSolver() {
+        final ConfigurationModule configurationModule = getConfigurationModule();
+        return new IssuersSolver(
+            configurationModule.getUserSelectionRepository(),
+            configurationModule.getPaymentSettings());
     }
 
     public CardTokenRepository getCardTokenRepository() {

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/GuessingCardPresenter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/GuessingCardPresenter.java
@@ -116,7 +116,10 @@ public abstract class GuessingCardPresenter extends BasePresenter<GuessingCard.V
             session.getCardTokenRepository(), session.getBankDealsRepository(),
             session.getIdentificationRepository(),
             session.getConfigurationModule().getPaymentSettings().getAdvancedConfiguration(),
-            paymentRecovery);
+            paymentRecovery,
+            session.getSummaryAmountRepository(),
+            session.provideIssuersSolver(),
+            session.providePayerCostSolver());
     }
 
     public static GuessingCardPresenter buildGuessingCardStoragePresenter(final Session session,

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/IssuersSolver.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/IssuersSolver.java
@@ -1,0 +1,49 @@
+package com.mercadopago.android.px.internal.features.guessing_card;
+
+import android.support.annotation.NonNull;
+import com.mercadopago.android.px.internal.repository.PaymentSettingRepository;
+import com.mercadopago.android.px.internal.repository.UserSelectionRepository;
+import com.mercadopago.android.px.model.Issuer;
+import com.mercadopago.android.px.preferences.CheckoutPreference;
+import java.util.List;
+
+public class IssuersSolver {
+
+    @NonNull private final UserSelectionRepository userSelectionRepository;
+    @NonNull private final PaymentSettingRepository paymentSettingRepository;
+
+    /**
+     * Constructor
+     *
+     * @param paymentSettingRepository Payment setting repository
+     * @param userSelectionRepository User selection repository.
+     */
+    public IssuersSolver(@NonNull final UserSelectionRepository userSelectionRepository,
+        @NonNull final PaymentSettingRepository paymentSettingRepository) {
+        this.userSelectionRepository = userSelectionRepository;
+        this.paymentSettingRepository = paymentSettingRepository;
+    }
+
+    /**
+     * Dispatches all issuers possible scenarios.
+     *
+     * @param listener The entity that will handle all possible flows.
+     * @param issuers The list of issuers.
+     */
+    public void solve(@NonNull final SummaryAmountListener listener, @NonNull final List<Issuer> issuers) {
+        if (issuers.size() == 1) {
+            final Issuer issuer = issuers.get(0);
+            // Mark as selected the issuer
+            userSelectionRepository.select(issuer);
+            final CheckoutPreference checkoutPreference = paymentSettingRepository.getCheckoutPreference();
+            //noinspection ConstantConditions
+            if (checkoutPreference.getPaymentPreference().getDefaultInstallments() == null) {
+                listener.onIssuerWithoutDefaultInstallment();
+            } else {
+                listener.onDefaultInstallmentSet();
+            }
+        } else {
+            listener.onMultipleIssuers(issuers);
+        }
+    }
+}

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/SummaryAmountListener.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/SummaryAmountListener.java
@@ -1,0 +1,24 @@
+package com.mercadopago.android.px.internal.features.guessing_card;
+
+import com.mercadopago.android.px.model.Issuer;
+import java.util.List;
+
+public interface SummaryAmountListener {
+
+    /**
+     * Handles if the checkout preference has a default installment set
+     */
+    void onDefaultInstallmentSet();
+
+    /**
+     * Handles the automatic issuer selection scenario such as only issuer option
+     */
+    void onIssuerWithoutDefaultInstallment();
+
+    /**
+     * Handles a multiple issuer list
+     * User must select issuer and then installments.
+     */
+    void onMultipleIssuers(final List<Issuer> issuers);
+
+}

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/installments/PayerCostSolver.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/installments/PayerCostSolver.java
@@ -47,4 +47,16 @@ public class PayerCostSolver {
             listener.onSelectedPayerCost();
         }
     }
+
+    /**
+     * Solve whether there is a default installment selected or not
+     */
+    public void solveDefaultInstallment(@NonNull final List<PayerCost> payerCosts) {
+        final PayerCost payerCost = paymentPreference.getDefaultInstallments(payerCosts);
+
+        if (payerCost != null) {
+            // Mark as selected a default payer cost
+            userSelectionRepository.select(payerCost);
+        }
+    }
 }

--- a/px-checkout/src/test/java/com/mercadopago/android/px/internal/features/guessing_card/IssuersSolverTest.java
+++ b/px-checkout/src/test/java/com/mercadopago/android/px/internal/features/guessing_card/IssuersSolverTest.java
@@ -1,0 +1,97 @@
+package com.mercadopago.android.px.internal.features.guessing_card;
+
+import com.mercadopago.android.px.internal.repository.PaymentSettingRepository;
+import com.mercadopago.android.px.internal.repository.UserSelectionRepository;
+import com.mercadopago.android.px.model.Issuer;
+import com.mercadopago.android.px.preferences.CheckoutPreference;
+import com.mercadopago.android.px.preferences.PaymentPreference;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IssuersSolverTest {
+
+    private static final Integer MOCKED_DEFAULT_INSTALLMENT = 6;
+    @Mock private PaymentSettingRepository paymentSettingRepository;
+    @Mock private UserSelectionRepository userSelectionRepository;
+
+    @Mock private SummaryAmountListener listener;
+    private List<Issuer> issuers;
+
+    private IssuersSolver solver;
+
+    @Before
+    public void setUp() {
+        issuers = new ArrayList<>();
+        solver = new IssuersSolver(userSelectionRepository, paymentSettingRepository);
+    }
+
+    @Test
+    public void whenDefaultInstallmentSelectedThenNotifyListener() {
+        mockIssuerListWithOneItem();
+        final CheckoutPreference mockCheckoutPref = mock(CheckoutPreference.class);
+        final PaymentPreference paymentPreference = mock(PaymentPreference.class);
+        when(paymentSettingRepository.getCheckoutPreference()).thenReturn(mockCheckoutPref);
+        assert paymentSettingRepository.getCheckoutPreference() != null;
+        when(mockCheckoutPref.getPaymentPreference()).thenReturn(paymentPreference);
+
+        when(paymentSettingRepository.getCheckoutPreference().getPaymentPreference().getDefaultInstallments())
+            .thenReturn(MOCKED_DEFAULT_INSTALLMENT);
+
+        solver.solve(listener, issuers);
+
+        verify(userSelectionRepository).select(issuers.get(0));
+        verify(listener).onDefaultInstallmentSet();
+    }
+
+    @Test
+    public void whenMultipleIssuersNotifyListener() {
+        mockIssuerListWithTwoItem();
+        solver.solve(listener, issuers);
+        verifyNoMoreInteractions(userSelectionRepository);
+        verify(listener).onMultipleIssuers(issuers);
+    }
+
+    @Test
+    public void whenSelectedIssuerWithoutDefaultInstallmentNotifyListener() {
+        mockIssuerListWithOneItem();
+        final CheckoutPreference mockCheckoutPref = mock(CheckoutPreference.class);
+        final PaymentPreference paymentPreference = mock(PaymentPreference.class);
+        when(paymentSettingRepository.getCheckoutPreference()).thenReturn(mockCheckoutPref);
+        assert paymentSettingRepository.getCheckoutPreference() != null;
+        when(mockCheckoutPref.getPaymentPreference()).thenReturn(paymentPreference);
+
+        when(paymentSettingRepository.getCheckoutPreference().getPaymentPreference().getDefaultInstallments())
+            .thenReturn(null);
+
+        solver.solve(listener, issuers);
+
+        verify(userSelectionRepository).select(issuers.get(0));
+        verify(listener).onIssuerWithoutDefaultInstallment();
+
+    }
+
+    private void mockIssuerListWithOneItem() {
+        issuers.clear();
+        final Issuer mockIssuer = mock(Issuer.class);
+        issuers.add(mockIssuer);
+    }
+
+    private void mockIssuerListWithTwoItem() {
+        issuers.clear();
+        final Issuer mockIssuer = mock(Issuer.class);
+        final Issuer anotherMockedIssuer = mock(Issuer.class);
+        issuers.add(mockIssuer);
+        issuers.add(anotherMockedIssuer);
+    }
+}

--- a/px-checkout/src/test/java/com/mercadopago/android/px/internal/features/installments/PayerCostSolverTest.java
+++ b/px-checkout/src/test/java/com/mercadopago/android/px/internal/features/installments/PayerCostSolverTest.java
@@ -79,4 +79,14 @@ public class PayerCostSolverTest {
         verify(listener).displayInstallments(filteredPayerCostsMock);
         verifyNoMoreInteractions(userSelectionRepository);
     }
+
+
+    @Test
+    public void whenDefaultPayerCostThenAutoSelectIt() {
+        final PayerCost payerCostMock = mock(PayerCost.class);
+        when(paymentPreference.getDefaultInstallments(payerCosts)).thenReturn(payerCostMock);
+
+        solver.solveDefaultInstallment(payerCosts);
+        verify(userSelectionRepository).select(payerCostMock);
+    }
 }


### PR DESCRIPTION
## Motivación y Contexto
Con una preferencia de pago con default installments veíamos una pantalla en blanco en el flujo de pago, cuando chequeaba si tenía que mostrar la selección de cuotas o seguir adelante.

## Descripción
Hicimos un prefetch de installments y un select del el default installment en el repositorio local para evitar ese chequeo innecesario. 

