### PR TITLE
Avoid crashing on Circle Transform without source config

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/util/CircleTransform.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/util/CircleTransform.java
@@ -1,20 +1,17 @@
 package com.mercadopago.android.px.internal.util;
 
-/**
- * Created by vaserber on 11/10/16.
- */
-
 import android.graphics.Bitmap;
 import android.graphics.BitmapShader;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.support.annotation.NonNull;
 import com.squareup.picasso.Transformation;
 
 public class CircleTransform implements Transformation {
 
     @Override
-    public Bitmap transform(final Bitmap source) {
-        int size = Math.min(source.getWidth(), source.getHeight());
+    public Bitmap transform(@NonNull final Bitmap source) {
+        final int size = Math.min(source.getWidth(), source.getHeight());
 
         final int x = (source.getWidth() - size) / 2;
         final int y = (source.getHeight() - size) / 2;
@@ -24,7 +21,8 @@ public class CircleTransform implements Transformation {
             source.recycle();
         }
 
-        final Bitmap bitmap = Bitmap.createBitmap(size, size, source.getConfig());
+        final Bitmap.Config config = source.getConfig() != null ? source.getConfig() : Bitmap.Config.ARGB_8888;
+        final Bitmap bitmap = Bitmap.createBitmap(size, size, config);
 
         final Canvas canvas = new Canvas(bitmap);
         final Paint paint = new Paint();

--- a/px-checkout/src/test/java/com/mercadopago/android/px/paymentvault/PaymentVaultPresenterTest.java
+++ b/px-checkout/src/test/java/com/mercadopago/android/px/paymentvault/PaymentVaultPresenterTest.java
@@ -161,7 +161,8 @@ public class PaymentVaultPresenterTest {
 
         verify(view).showAmount(discountRepository.getCurrentConfiguration(),
                 checkoutPreference.getTotalAmount(), mockSite);
-        verify(view).startCardFlow(anyBoolean());
+        verify(view).saveAutomaticSelection(true);
+        verify(view).startCardFlow();
         verify(paymentSettingRepository, atLeastOnce()).getCheckoutPreference();
         verify(userSelectionRepository, times(1)).select(PaymentTypes.CREDIT_CARD);
         verify(view).setTitle(paymentVaultTitleSolver.solveTitle());
@@ -479,7 +480,7 @@ public class PaymentVaultPresenterTest {
         }
 
         @Override
-        public void startCardFlow(final Boolean automaticallySelection) {
+        public void startCardFlow() {
             cardFlowStarted = true;
         }
 
@@ -536,6 +537,11 @@ public class PaymentVaultPresenterTest {
 
         /* default */ void simulateCustomItemSelection(final int index) {
             customItemSelectionCallback.onSelected(customOptionsShown.get(index));
+        }
+
+        @Override
+        public void saveAutomaticSelection(final boolean automaticSelection) {
+            //Not yet tested
         }
     }
 }


### PR DESCRIPTION
Crasheaba el Summary de One Tap cuando la imagen del collector es un GIF.