### PR TITLE
[fix] on payment vault back after reject & recover payment change, keeps one tap button in progress

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentFragment.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentFragment.java
@@ -461,8 +461,8 @@ public class ExpressPaymentFragment extends Fragment implements ExpressPayment.V
         showConfirmButton();
         final FragmentManager childFragmentManager = getChildFragmentManager();
         final ExplodingFragment fragment =
-            (ExplodingFragment) FragmentUtil.getFragmentByTag(childFragmentManager, TAG_EXPLODING_FRAGMENT);
-        if (fragment != null && fragment.hasFinished()) {
+            (ExplodingFragment) childFragmentManager.findFragmentByTag(TAG_EXPLODING_FRAGMENT);
+        if (fragment != null && fragment.isAdded() && fragment.hasFinished()) {
             childFragmentManager
                 .beginTransaction()
                 .remove(fragment)


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
<!--- ¿Por qué este cambio es requerido? ¿Qué problema resuelve? -->
Al hacer back en la pantalla de payment vault, luego de haber elegido cambiar medio de pago en la pantalla de recuperos y rechazos, el botón de pagar en one tap queda en progreso indefinidamente y no deja al usuario hacer más nada.

## Descripción
<!--- Describir los cambios en detalle -->
- Se quita el uso de FragmentUtil el cual válida que sea visible y al momento de cancelar el loading nos interesa si ya terminó y no si es visible.
## Cómo probarlo
<!--- Para bug fixes: Describir cómo reproducir el comportamiento que generaba el bug -->
<!--- Para nuevos features: Se debe agregar el caso de uso a la app de ejemplos, y aquí se debe describir qué función de la app de ejemplos probar -->
- Generar un pago con Payment.StatusCodes.STATUS_REJECTED y Payment.StatusDetail.STATUS_DETAIL_CC_REJECTED_HIGH_RISK o cualquier combinación que te permita cambiar el medio de pago en recuperos y rechazos.
- Al ingresar a payment vault para seleccionar el medio de pago, hacer back.
## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
