### PR TITLE
Added change payment method driver to keep one tap flow after payment rejection

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/CheckoutPresenter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/CheckoutPresenter.java
@@ -9,6 +9,7 @@ import com.mercadopago.android.px.internal.callbacks.TaggedCallback;
 import com.mercadopago.android.px.internal.configuration.InternalConfiguration;
 import com.mercadopago.android.px.internal.features.providers.CheckoutProvider;
 import com.mercadopago.android.px.internal.navigation.DefaultPaymentMethodDriver;
+import com.mercadopago.android.px.internal.navigation.OnChangePaymentMethodDriver;
 import com.mercadopago.android.px.internal.repository.GroupsRepository;
 import com.mercadopago.android.px.internal.repository.PaymentRepository;
 import com.mercadopago.android.px.internal.repository.PaymentSettingRepository;
@@ -23,7 +24,6 @@ import com.mercadopago.android.px.model.Card;
 import com.mercadopago.android.px.model.Cause;
 import com.mercadopago.android.px.model.IPaymentDescriptor;
 import com.mercadopago.android.px.model.IPaymentDescriptorHandler;
-import com.mercadopago.android.px.model.IPayment;
 import com.mercadopago.android.px.model.Payment;
 import com.mercadopago.android.px.model.PaymentMethodSearch;
 import com.mercadopago.android.px.model.PaymentRecovery;
@@ -494,22 +494,33 @@ public class CheckoutPresenter extends MvpPresenter<CheckoutView, CheckoutProvid
         recoverPayment();
     }
 
-    //TODO separate with better navigation when we have a proper driver.
     @Override
     public void onChangePaymentMethod() {
         state.paymentMethodEdited = true;
         getView().transitionOut();
 
-        if (internalConfiguration.shouldExitOnPaymentMethodChange()) {
-            final IPayment payment = paymentRepository.getPayment();
-            if (payment instanceof Payment) {
-                getView().finishWithPaymentResult(Constants.RESULT_CHANGE_PAYMENT_METHOD, (Payment) payment);
-            } else {
-                getView().finishWithPaymentResult(Constants.RESULT_CHANGE_PAYMENT_METHOD);
-            }
-        } else {
-            getView().showPaymentMethodSelection();
-        }
+        new OnChangePaymentMethodDriver(internalConfiguration, state, paymentRepository)
+            .drive(new OnChangePaymentMethodDriver.ChangePaymentMethodDriverCallback() {
+                @Override
+                public void driveToFinishWithPaymentResult(final Integer resultCode, final Payment payment) {
+                    getView().finishWithPaymentResult(resultCode, payment);
+                }
+
+                @Override
+                public void driveToFinishWithoutPaymentResult(final Integer resultCode) {
+                    getView().finishWithPaymentResult(resultCode);
+                }
+
+                @Override
+                public void driveToShowOneTap() {
+                    getView().showOneTap();
+                }
+
+                @Override
+                public void driveToShowPaymentMethodSelection() {
+                    getView().showPaymentMethodSelection();
+                }
+            });
     }
 
     //TODO separate with better navigation when we have a proper driver.

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/navigation/OnChangePaymentMethodDriver.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/navigation/OnChangePaymentMethodDriver.java
@@ -1,0 +1,52 @@
+package com.mercadopago.android.px.internal.navigation;
+
+import android.support.annotation.NonNull;
+import com.mercadopago.android.px.internal.configuration.InternalConfiguration;
+import com.mercadopago.android.px.internal.repository.PaymentRepository;
+import com.mercadopago.android.px.internal.viewmodel.CheckoutStateModel;
+import com.mercadopago.android.px.model.IPaymentDescriptor;
+import com.mercadopago.android.px.model.Payment;
+
+import static com.mercadopago.android.px.internal.features.Constants.RESULT_CHANGE_PAYMENT_METHOD;
+
+public class OnChangePaymentMethodDriver {
+
+    @NonNull private final InternalConfiguration internalConfiguration;
+    @NonNull private final CheckoutStateModel checkoutStateModel;
+    @NonNull private final PaymentRepository paymentRepository;
+
+    public OnChangePaymentMethodDriver(@NonNull final InternalConfiguration internalConfiguration,
+        @NonNull final CheckoutStateModel checkoutStateModel, @NonNull final PaymentRepository paymentRepository) {
+        this.internalConfiguration = internalConfiguration;
+        this.checkoutStateModel = checkoutStateModel;
+        this.paymentRepository = paymentRepository;
+    }
+
+    public void drive(final ChangePaymentMethodDriverCallback callback) {
+        if (internalConfiguration.shouldExitOnPaymentMethodChange()) {
+            final IPaymentDescriptor payment = paymentRepository.getPayment();
+            if (payment instanceof Payment) {
+                callback.driveToFinishWithPaymentResult(RESULT_CHANGE_PAYMENT_METHOD, (Payment) payment);
+            } else {
+                // Should we track this?
+                callback.driveToFinishWithoutPaymentResult(RESULT_CHANGE_PAYMENT_METHOD);
+            }
+        } else {
+            if (checkoutStateModel.isExpressCheckout) {
+                callback.driveToShowOneTap();
+            } else {
+                callback.driveToShowPaymentMethodSelection();
+            }
+        }
+    }
+
+    public interface ChangePaymentMethodDriverCallback {
+        void driveToFinishWithPaymentResult(Integer resultCode, Payment payment);
+
+        void driveToFinishWithoutPaymentResult(Integer resultCode);
+
+        void driveToShowOneTap();
+
+        void driveToShowPaymentMethodSelection();
+    }
+}


### PR DESCRIPTION
## Motivación y Contexto
Cuando caemos en un resultado de error pagando en un flujo de one tap, al intentar cambiar el método de pago nos lleva a la selección por grupo. Queremos que si es one tap no nos saque de ese flujo. 

