### PR TITLE
[hotfix] Fixed tracking of session_id

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/core/internal/MercadoPagoCardStorage.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/core/internal/MercadoPagoCardStorage.java
@@ -54,6 +54,7 @@ public final class MercadoPagoCardStorage implements Parcelable {
 
     /**
      * Lets us know if we have to skip result screen or not
+     *
      * @return true/false to skip Result screen
      */
     public boolean shouldSkipResultScreen() {
@@ -75,7 +76,7 @@ public final class MercadoPagoCardStorage implements Parcelable {
      */
     public void start(@NonNull final Context context) {
         //start new session id
-        MPTracker.getInstance().setSessionId(new ApplicationModule(context).getSessionIdProvider().getSessionId());
+        MPTracker.getInstance().setSessionId(new ApplicationModule(context).newSessionIdProvider().getSessionId());
 
         GuessingCardActivity.startGuessingCardActivityForStorage(context, this);
     }
@@ -95,7 +96,6 @@ public final class MercadoPagoCardStorage implements Parcelable {
      * @param accessToken logged in user access token
      * @param requestCode it's the number that identifies the checkout flow request for
      * {@link Activity#onActivityResult(int, int, Intent)}
-     *
      * @deprecated use {@link #MercadoPagoCardStorage(Builder)}
      */
     @Deprecated
@@ -121,7 +121,6 @@ public final class MercadoPagoCardStorage implements Parcelable {
      * @param accessToken logged in user access token
      * @param requestCode it's the number that identifies the checkout flow request for {@link
      * Activity#onActivityResult(int, int, Intent)}
-     *
      * @deprecated use {@link #MercadoPagoCardStorage(Builder)}
      */
     @Deprecated

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/di/Session.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/di/Session.java
@@ -108,7 +108,7 @@ public final class Session extends ApplicationModule
         clear();
 
         //start new session id
-        MPTracker.getInstance().setSessionId(getSessionIdProvider().getSessionId());
+        MPTracker.getInstance().setSessionId(newSessionIdProvider().getSessionId());
 
         // Store persistent paymentSetting
         final ConfigurationModule configurationModule = getConfigurationModule();

--- a/px-checkout/src/main/java/com/mercadopago/android/px/tracking/internal/MPTracker.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/tracking/internal/MPTracker.java
@@ -2,6 +2,7 @@ package com.mercadopago.android.px.tracking.internal;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 import com.mercadopago.android.px.model.Event;
 import com.mercadopago.android.px.model.ScreenViewEvent;
 import com.mercadopago.android.px.tracking.PXEventListener;

--- a/px-checkout/src/main/java/com/mercadopago/android/px/tracking/internal/MPTracker.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/tracking/internal/MPTracker.java
@@ -2,7 +2,6 @@ package com.mercadopago.android.px.tracking.internal;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Log;
 import com.mercadopago.android.px.model.Event;
 import com.mercadopago.android.px.model.ScreenViewEvent;
 import com.mercadopago.android.px.tracking.PXEventListener;

--- a/px-services/src/main/java/com/mercadopago/android/px/internal/core/ApplicationModule.java
+++ b/px-services/src/main/java/com/mercadopago/android/px/internal/core/ApplicationModule.java
@@ -3,7 +3,6 @@ package com.mercadopago.android.px.internal.core;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mercadopago.android.px.internal.util.JsonUtil;
 import com.mercadopago.android.px.internal.util.RetrofitUtil;
 import java.io.File;

--- a/px-services/src/main/java/com/mercadopago/android/px/internal/core/ApplicationModule.java
+++ b/px-services/src/main/java/com/mercadopago/android/px/internal/core/ApplicationModule.java
@@ -3,6 +3,7 @@ package com.mercadopago.android.px.internal.core;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import com.mercadopago.android.px.internal.util.JsonUtil;
 import com.mercadopago.android.px.internal.util.RetrofitUtil;
 import java.io.File;
@@ -12,6 +13,7 @@ public class ApplicationModule implements PreferenceComponent {
 
     @NonNull
     private final Context context;
+    private SessionIdProvider sessionIdProvider;
 
     public ApplicationModule(@NonNull final Context context) {
         this.context = context.getApplicationContext();
@@ -24,7 +26,16 @@ public class ApplicationModule implements PreferenceComponent {
 
     @NonNull
     public SessionIdProvider getSessionIdProvider() {
-        return SessionIdProvider.create(getSharedPreferences());
+        if (sessionIdProvider == null) {
+            sessionIdProvider = SessionIdProvider.createFromStorage(getSharedPreferences());
+        }
+        return sessionIdProvider;
+    }
+
+    @NonNull
+    public SessionIdProvider newSessionIdProvider() {
+        sessionIdProvider = SessionIdProvider.create(getSharedPreferences());
+        return sessionIdProvider;
     }
 
     @Override

--- a/px-services/src/main/java/com/mercadopago/android/px/internal/core/SessionIdProvider.java
+++ b/px-services/src/main/java/com/mercadopago/android/px/internal/core/SessionIdProvider.java
@@ -13,12 +13,19 @@ public final class SessionIdProvider {
     @Nullable private String id;
 
     public static SessionIdProvider create(@NonNull final SharedPreferences sharedPreferences) {
-        return new SessionIdProvider(sharedPreferences);
+        final SessionIdProvider instance = new SessionIdProvider(sharedPreferences);
+        instance.id = UUID.randomUUID().toString();
+        sharedPreferences.edit().putString(PREF_SESSION_ID, instance.id).apply();
+        return instance;
+    }
+
+    public static SessionIdProvider createFromStorage(@NonNull final SharedPreferences sharedPreferences) {
+        final SessionIdProvider instance = new SessionIdProvider(sharedPreferences);
+        instance.id = sharedPreferences.getString(PREF_SESSION_ID, "no-value");
+        return instance;
     }
 
     private SessionIdProvider(@NonNull final SharedPreferences sharedPreferences) {
-        id = UUID.randomUUID().toString();
-        sharedPreferences.edit().putString(PREF_SESSION_ID, id).apply();
         this.sharedPreferences = sharedPreferences;
     }
 


### PR DESCRIPTION
Se generaban múltiples session_id en el interceptor de los request.