### PR TITLE
[hotfix] Fixed payment result tracking

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/tracking/internal/model/ResultViewTrackModel.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/tracking/internal/model/ResultViewTrackModel.java
@@ -4,13 +4,14 @@ import android.support.annotation.NonNull;
 import com.mercadopago.android.px.internal.util.PaymentDataHelper;
 import com.mercadopago.android.px.model.PaymentResult;
 import com.mercadopago.android.px.preferences.CheckoutPreference;
-import com.mercadopago.android.px.tracking.internal.mapper.FromPaymentMethodToAvailableMethods;
 import com.mercadopago.android.px.tracking.internal.views.ResultViewTrack;
 import java.math.BigDecimal;
 
 public final class ResultViewTrackModel extends TrackingMapModel {
 
     private final String style;
+    private String paymentMethodId;
+    private String paymentMethodType;
     private final Long paymentId;
     private final String paymentStatus;
     private final String paymentStatusDetail;
@@ -18,7 +19,6 @@ public final class ResultViewTrackModel extends TrackingMapModel {
     private final boolean hasSplitPayment;
     private final BigDecimal preferenceAmount;
     private final BigDecimal discountCouponAmount;
-    private AvailableMethod availableMethod;
 
     public ResultViewTrackModel(@NonNull final ResultViewTrack.Style style, @NonNull final PaymentResult payment,
         @NonNull final CheckoutPreference checkoutPreference) {
@@ -32,8 +32,8 @@ public final class ResultViewTrackModel extends TrackingMapModel {
         discountCouponAmount = PaymentDataHelper.getTotalDiscountAmount(payment.getPaymentDataList());
 
         if (payment.getPaymentData() != null && payment.getPaymentData().getPaymentMethod() != null) {
-            availableMethod =
-                new FromPaymentMethodToAvailableMethods().map(payment.getPaymentData().getPaymentMethod());
+            paymentMethodId = payment.getPaymentData().getPaymentMethod().getId();
+            paymentMethodType = payment.getPaymentData().getPaymentMethod().getPaymentTypeId();
         }
     }
 


### PR DESCRIPTION
La estructura del track que se enviaba en PaymentResult no era la correcta.

## Motivación y Contexto
Se están generando tracks inválidos.

## Descripción
- Se sacaron los atributos payment_method_id y payment_method_type de available methods y se los colocó en el mismo nivel que el resto de los atributos. 

- El atributo available_methods no se envía más en los tracks de PaymentResult.

- El atributo extra_info no se envía en los tracks de PaymentResult. Antes se estaba enviando en null. Es un campo no requerido en Melidata. 

## Cómo probarlo
Crear un PXTrackingListener, setearlo en MPTracker y loguear los tracks.
