### PR TITLE
Fix payment result methods layout

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/util/ViewUtils.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/util/ViewUtils.java
@@ -36,8 +36,6 @@ import com.squareup.picasso.Picasso;
 import javax.annotation.Nonnull;
 import uk.co.chrisjenx.calligraphy.TypefaceUtils;
 
-import static android.view.View.GONE;
-
 public final class ViewUtils {
 
     private ViewUtils() {
@@ -73,7 +71,7 @@ public final class ViewUtils {
         }
     }
 
-    public static void loadOrCallError(final String imgUrl, final ImageView logo, Callback callback) {
+    public static void loadOrCallError(final String imgUrl, final ImageView logo, final Callback callback) {
         if (!TextUtil.isEmpty(imgUrl)) {
             Picasso.with(logo.getContext())
                 .load(imgUrl)
@@ -85,9 +83,10 @@ public final class ViewUtils {
 
     public static void loadOrGone(@Nullable final CharSequence text, @NonNull final TextView textView) {
         if (TextUtil.isEmpty(text)) {
-            textView.setVisibility(GONE);
+            textView.setVisibility(View.GONE);
         } else {
             textView.setText(text);
+            textView.setVisibility(View.VISIBLE);
         }
     }
 
@@ -101,6 +100,7 @@ public final class ViewUtils {
             imageView.setVisibility(View.GONE);
         } else {
             imageView.setImageResource(resId);
+            imageView.setVisibility(View.VISIBLE);
         }
     }
 
@@ -145,17 +145,17 @@ public final class ViewUtils {
         showLayout(activity, false, true);
     }
 
-    private static void showLayout(Activity activity, final boolean showProgress, final boolean showLayout) {
+    private static void showLayout(final Activity activity, final boolean showProgress, final boolean showLayout) {
 
         final View form = activity.findViewById(R.id.mpsdkRegularLayout);
         final View progress = activity.findViewById(R.id.mpsdkProgressLayout);
 
         if (progress != null) {
-            progress.setVisibility(showLayout ? GONE : View.VISIBLE);
+            progress.setVisibility(showLayout ? View.GONE : View.VISIBLE);
         }
 
         if (form != null) {
-            form.setVisibility(showProgress ? GONE : View.VISIBLE);
+            form.setVisibility(showProgress ? View.GONE : View.VISIBLE);
         }
     }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/PaymentMethodBodyComponent.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/PaymentMethodBodyComponent.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
@@ -83,6 +84,7 @@ public class PaymentMethodBodyComponent
 
         final Context context = parent.getContext();
         final LinearLayout linearContainer = ViewUtils.createLinearContainer(context);
+        linearContainer.setGravity(Gravity.CENTER_VERTICAL);
         PaymentMethodComponent paymentMethodComponent;
         final Iterator<PaymentMethodComponent.PaymentMethodProps> paymentMethodPropsIterator =
             props.paymentMethodProps.iterator();

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/PaymentMethodComponent.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/PaymentMethodComponent.java
@@ -109,8 +109,8 @@ public class PaymentMethodComponent extends CompactComponent<PaymentMethodCompon
         descriptionTextView
             .setText(getDescription(props.paymentMethod.getName(), props.paymentMethod.getPaymentTypeId(),
                 props.lastFourDigits, context));
-        statementDescriptionTextView.setText(getDisclaimer(props.paymentMethod.getPaymentTypeId(),
-            props.disclaimer, context));
+        final String disclaimerText = getDisclaimer(props.paymentMethod.getPaymentTypeId(), props.disclaimer, context);
+        ViewUtils.loadOrGone(disclaimerText, statementDescriptionTextView);
         return paymentMethodView;
     }
 


### PR DESCRIPTION
El layout de cada método de pago en la Congrats tenía ciertos problemas, mostraba una view fantasma que a veces no iba y no centraba correctamente si había espacio.