### PR TITLE
[fix] remove path variable from card issuers service

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/CardAssociationService.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/CardAssociationService.java
@@ -37,6 +37,6 @@ public class CardAssociationService {
     public MPCall<List<Issuer>> getCardIssuers(@NonNull final String accessToken, @NonNull final String paymentMethodId,
         @NonNull final String bin) {
         return cardService
-            .getCardIssuers(API_ENVIRONMENT, accessToken, paymentMethodId, bin, ProcessingMode.AGGREGATOR.asQueryParamName());
+            .getCardIssuers(accessToken, paymentMethodId, bin, ProcessingMode.AGGREGATOR.asQueryParamName());
     }
 }

--- a/px-services/src/main/java/com/mercadopago/android/px/internal/services/CardService.java
+++ b/px-services/src/main/java/com/mercadopago/android/px/internal/services/CardService.java
@@ -16,9 +16,8 @@ public interface CardService {
     MPCall<Card> assignCard(@Path(value = "version", encoded = true) String version,
         @Query("access_token") String accessToken, @Body HashMap<String, Object> body);
 
-    @GET("/{version}/payment_methods/card_issuers")
-    MPCall<List<Issuer>> getCardIssuers(@Path(value = "version", encoded = true) String version,
-        @Query("access_token") String accessToken,
+    @GET("/v1/payment_methods/card_issuers")
+    MPCall<List<Issuer>> getCardIssuers(@Query("access_token") String accessToken,
         @Query("payment_method_id") String paymentMethodId, @Query("bin") String bin,
         @Query("processing_mode") String processingMode);
 


### PR DESCRIPTION
Se elimina la variable de path del endpoint de card_issuers usado en alta de tarjeta exclusivamente, debido a que este endpoint no es nuestro y no tenemos un beta para probar, lo que ocasiona que falle la alta de tarjeta contra beta. Se fija el path directamente a v1.