### PR TITLE
[enhancement] add validator for payment processors

### DIFF
--- a/px-testlib/src/main/java/com/mercadopago/android/px/testcheckout/assertions/ProcessorValidator.java
+++ b/px-testlib/src/main/java/com/mercadopago/android/px/testcheckout/assertions/ProcessorValidator.java
@@ -1,0 +1,9 @@
+package com.mercadopago.android.px.testcheckout.assertions;
+
+import android.support.annotation.NonNull;
+
+import com.mercadopago.android.px.core.SplitPaymentProcessor;
+
+public interface ProcessorValidator {
+    void validate(@NonNull final SplitPaymentProcessor.CheckoutData checkoutData);
+}

--- a/testlib/src/main/java/com/mercadopago/android/testlib/idlingresource/ActivityIdlingResource.java
+++ b/testlib/src/main/java/com/mercadopago/android/testlib/idlingresource/ActivityIdlingResource.java
@@ -6,6 +6,7 @@ import android.support.test.espresso.IdlingResource;
 import android.support.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
 import android.support.test.runner.lifecycle.Stage;
 import java.util.Collection;
+import java.util.Iterator;
 
 public class ActivityIdlingResource implements IdlingResource {
 
@@ -41,7 +42,10 @@ public class ActivityIdlingResource implements IdlingResource {
         final Activity[] mActivity = new Activity[1];
         final Collection<Activity> resumedActivities =
             ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(Stage.RESUMED);
-        mActivity[0] = resumedActivities.iterator().next();
+        Iterator<Activity> iterator = resumedActivities.iterator();
+        if (iterator.hasNext()) {
+            mActivity[0] = iterator.next();
+        }
         return mActivity[0];
     }
 }


### PR DESCRIPTION
Se agrega ProcessorValidator a px-testlib para poder incluir validaciones de la procesadora de pago en los test de regresión.

Se fixea lógica en ActivityIdlingResource donde se podía producir una excepción si el iterador está vacío