### PR TITLE
[Feature] Fraud Device Tracking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ subprojects {
         mavenLocal()
         google()
         jcenter()
+        maven {
+            url "https://dl.bintray.com/mercadolibre/android-public"
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,7 @@ retrofit=2.4.0
 picasso=2.5.2
 leak_cannary=1.5.4
 meli_ui_lib=7.+
+device_sdk=1.0.8
 multidex=1.0.3
 # test dependencies
 spoon_client=1.7.1

--- a/px-checkout/build.gradle
+++ b/px-checkout/build.gradle
@@ -37,4 +37,5 @@ dependencies {
     implementation "com.google.code.gson:gson:$gson"
     implementation "com.squareup.picasso:picasso:$picasso"
     implementation "com.mercadolibre.android:ui:$meli_ui_lib"
+    implementation "com.mercadolibre.android.device:sdk:$device_sdk"
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmBuilder.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmBuilder.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.support.annotation.NonNull;
+
+import com.mercadolibre.android.device.sdk.DeviceSDK;
 import com.mercadopago.android.px.R;
 import com.mercadopago.android.px.internal.di.ConfigurationModule;
 import com.mercadopago.android.px.internal.di.Session;
@@ -25,6 +27,7 @@ import com.mercadopago.android.px.model.PaymentMethod;
 import com.mercadopago.android.px.model.Site;
 import com.mercadopago.android.px.model.Token;
 import com.mercadopago.android.px.preferences.CheckoutPreference;
+
 import java.util.List;
 
 public class ReviewAndConfirmBuilder {
@@ -105,6 +108,20 @@ public class ReviewAndConfirmBuilder {
                 discountTermsAndConditions,
                 postPaymentAction);
         }
+
+        DeviceSDK.getInstance()
+                .withCustomAttribute("payment_method_id", paymentModel.paymentMethodId)
+                .withCustomAttribute("payment_method_name", paymentModel.paymentMethodName)
+                .withCustomAttribute("card_token", token != null ? token.getId() : null)
+                .withCustomAttribute("preference_id", checkoutPreference.getId())
+                .withCustomAttribute("marketplace", checkoutPreference.getMarketplace())
+                .withCustomAttribute("operation_type", checkoutPreference.getOperationType())
+                .withCustomAttribute("site_id", site.getId())
+                .withCustomAttribute("public_key", publicKey)
+                .withCustomAttribute("transaction_id", paymentSettings.getTransactionId())
+                .withCustomAttribute("session_id", session.getSessionIdProvider().getSessionId())
+                .execute(context);
+
         return ReviewAndConfirmActivity.getIntent(context,
             publicKey,
             mercadoPagoTermsAndConditions,


### PR DESCRIPTION
## Motivación y Contexto
Es importante contar con información del dispositivo a la hora de tener en cuenta determinadas variables que sirven como input a los modelos que aprueban / rechazan los pagos. El tracking de device mediante la librería `com.mercadolibre.android.device.sdk.DeviceSDK` provee una manera simplificada de obtener esta información en el backend.

## Descripción
La integración del SDK de Device instancia un nuevo objeto de la clase `DeviceSDK`. Este objeto internamente levanta un conjunto de **DataCollectors**. Los DataCollectors capturan información relacionada a:

* Device
* Screen
* Application 
* Contexto del checkout
* Location **(sólo si está habilitada)**

La captura y envío de la información es totalmente **asíncrona** y **no bloqueante**. Es decir, la ejecución del SDK de Device no afecta ni bloquea el flujo de pago. Además **todos los módulos** que componen el SDK de Device no disparan ningún tipo de excepción, sino las capturan internamente. Además, la información viaja encriptada hacia nuestro backend.

## Cómo probarlo
Para probar la integración, se debe iniciar un nuevo flujo de pago (cualquier medio de pago) y llegado el step de review, se instancia el SDK de Device. Se debe chequear que se realice un post con el siguiente formato:

```json
{
    "bd": "encrypted-device-data",
    "check": "encrypted-key",
}
```

## Screenshots
No aplica cambios a nivel visual.

## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
- [ ] Mi cambio afecta a integradores internos

## Compartir conocimiento
Para el cambio se utilizó la [Librería de SDK de Device](https://github.com/mercadolibre/fury_fraud-device-sdk.git)
