### PR TITLE
[fix] double payment in one tap

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentFragment.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentFragment.java
@@ -515,6 +515,7 @@ public class ExpressPaymentFragment extends Fragment implements ExpressPayment.V
     }
 
     private void hideConfirmButton() {
+        confirmButton.setClickable(false);
         confirmButton.clearAnimation();
         confirmButton.setVisibility(INVISIBLE);
     }
@@ -531,8 +532,8 @@ public class ExpressPaymentFragment extends Fragment implements ExpressPayment.V
 
     @Override
     public void startLoadingButton(final int paymentTimeout, @NonNull final PayButtonViewModel payButtonViewModel) {
+        hideConfirmButton();
         ViewUtils.runWhenViewIsFullyMeasured(getView(), () -> {
-            hideConfirmButton();
             final ExplodeParams explodeParams = ExplodingFragment.getParams(confirmButton,
                 payButtonViewModel.getButtonProgressText(confirmButton.getContext()), paymentTimeout);
             final FragmentManager childFragmentManager = getChildFragmentManager();


### PR DESCRIPTION
En one tap, el botón de confirmar payment no se llega a actualizar al presionarlo y permite presionarlo varias veces.

* Se hace un setClickable(false) en el primer click
* El estado del botón se recupera en el update de ConfirmButtonAdapter