### PR TITLE
[enhancement] killing card vault #1

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/SecurityCodeActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/SecurityCodeActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.MotionEventCompat;
 import android.support.v7.widget.Toolbar;
@@ -80,6 +81,22 @@ public class SecurityCodeActivity extends PXActivity<SecurityCodePresenter> impl
     protected FrameLayout mCardContainer;
     protected CardView mCardView;
     protected MPTextView mTimerTextView;
+
+    public static void startForSavedCard(@NonNull final Card card, final Fragment fragment, final int reqCode) {
+        //noinspection ConstantConditions
+        final Intent intent = createIntent(fragment.getContext(), card);
+        fragment.startActivityForResult(intent, reqCode);
+    }
+
+    private static Intent createIntent(@NonNull final Context context, @NonNull final Card card) {
+        // TODO remove serialization as Json.
+        final Intent intent = new Intent(context, SecurityCodeActivity.class);
+        intent.putExtra(EXTRA_CARD_INFO, JsonUtil.getInstance().toJson(new CardInfo(card)));
+        intent.putExtra(EXTRA_CARD, JsonUtil.getInstance().toJson(card));
+        intent.putExtra(EXTRA_PAYMENT_METHOD, JsonUtil.getInstance().toJson(card.getPaymentMethod()));
+        intent.putExtra(EXTRA_REASON, Reason.SAVED_CARD.name());
+        return intent;
+    }
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
@@ -455,6 +472,10 @@ public class SecurityCodeActivity extends PXActivity<SecurityCodePresenter> impl
         finish();
     }
 
+    /**
+     * @deprecated Use static factory methods
+     */
+    @Deprecated
     public static final class Builder {
         private CardInfo cardInformation;
         private PaymentMethod paymentMethod;

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/cardvault/CardVaultActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/cardvault/CardVaultActivity.java
@@ -48,7 +48,7 @@ public class CardVaultActivity extends PXActivity<CardVaultPresenter> implements
     private CardVaultPresenter presenter;
 
     @SuppressWarnings("TypeMayBeWeakened")
-    public static void startActivity(@NonNull final Activity context, final int reqCode,
+    public static void startActivityForRecovery(@NonNull final Activity context, final int reqCode,
         @NonNull final PaymentRecovery paymentRecovery) {
         final Intent intent = new Intent(context, CardVaultActivity.class);
         intent.putExtra(EXTRA_PAYMENT_RECOVERY, paymentRecovery);
@@ -56,7 +56,7 @@ public class CardVaultActivity extends PXActivity<CardVaultPresenter> implements
     }
 
     @SuppressWarnings("TypeMayBeWeakened")
-    public static void startActivity(final Fragment oneTapFragment, final int reqCode,
+    public static void startActivityForRecovery(final Fragment oneTapFragment, final int reqCode,
         @NonNull final PaymentRecovery paymentRecovery) {
         final Intent intent = new Intent(oneTapFragment.getActivity(), CardVaultActivity.class);
         intent.putExtra(EXTRA_PAYMENT_RECOVERY, paymentRecovery);
@@ -66,11 +66,6 @@ public class CardVaultActivity extends PXActivity<CardVaultPresenter> implements
     public static void startActivity(@NonNull final Activity context, final int reqCode) {
         final Intent intent = new Intent(context, CardVaultActivity.class);
         context.startActivityForResult(intent, reqCode);
-    }
-
-    public static void startActivity(final Fragment oneTapFragment, final int reqCode) {
-        final Intent intent = new Intent(oneTapFragment.getActivity(), CardVaultActivity.class);
-        oneTapFragment.startActivityForResult(intent, reqCode);
     }
 
     private void configure() {

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutActivity.java
@@ -473,7 +473,7 @@ public class CheckoutActivity extends PXActivity<CheckoutPresenter>
 
     @Override
     public void startPaymentRecoveryFlow(final PaymentRecovery paymentRecovery) {
-        CardVaultActivity.startActivity(this, REQ_CARD_VAULT, paymentRecovery);
+        CardVaultActivity.startActivityForRecovery(this, REQ_CARD_VAULT, paymentRecovery);
         overrideTransitionIn();
     }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPayment.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPayment.java
@@ -28,7 +28,7 @@ public interface ExpressPayment {
 
         void cancel();
 
-        void showCardFlow(@NonNull final Card card);
+        void showSecurityCodeScreen(@NonNull final Card card);
 
         void showCardFlow(@NonNull PaymentRecovery paymentRecovery);
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentFragment.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentFragment.java
@@ -30,6 +30,7 @@ import com.mercadopago.android.px.R;
 import com.mercadopago.android.px.core.DynamicDialogCreator;
 import com.mercadopago.android.px.internal.di.Session;
 import com.mercadopago.android.px.internal.features.Constants;
+import com.mercadopago.android.px.internal.features.SecurityCodeActivity;
 import com.mercadopago.android.px.internal.features.cardvault.CardVaultActivity;
 import com.mercadopago.android.px.internal.features.checkout.CheckoutActivity;
 import com.mercadopago.android.px.internal.features.explode.ExplodeDecorator;
@@ -94,6 +95,7 @@ public class ExpressPaymentFragment extends Fragment implements ExpressPayment.V
     private static final String EXTRA_RENDER_MODE = "render_mode";
     private static final int REQ_CODE_CARD_VAULT = 0x999;
     private static final int REQ_CODE_PAYMENT_PROCESSOR = 0x123;
+    private static final int REQ_CODE_SECURITY_CODE = 18;
     private static final float PAGER_NEGATIVE_MARGIN_MULTIPLIER = -1.5f;
 
     // Width / Height
@@ -396,6 +398,8 @@ public class ExpressPaymentFragment extends Fragment implements ExpressPayment.V
     public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
         if (requestCode == REQ_CODE_CARD_VAULT && resultCode == RESULT_OK) {
             presenter.onTokenResolved();
+        } else if (requestCode == REQ_CODE_SECURITY_CODE && resultCode == RESULT_OK) {
+            presenter.onTokenResolved();
         } else if (requestCode == REQ_CODE_CARD_VAULT && resultCode == RESULT_CANCELED) {
             presenter.trackExpressView();
             super.onActivityResult(requestCode, resultCode, data);
@@ -545,13 +549,13 @@ public class ExpressPaymentFragment extends Fragment implements ExpressPayment.V
     }
 
     @Override
-    public void showCardFlow(@NonNull final Card card) {
-        CardVaultActivity.startActivity(this, REQ_CODE_CARD_VAULT);
+    public void showSecurityCodeScreen(@NonNull final Card card) {
+        SecurityCodeActivity.startForSavedCard(card, this, REQ_CODE_SECURITY_CODE);
     }
 
     @Override
     public void showCardFlow(@NonNull final PaymentRecovery paymentRecovery) {
-        CardVaultActivity.startActivity(this, REQ_CODE_CARD_VAULT, paymentRecovery);
+        CardVaultActivity.startActivityForRecovery(this, REQ_CODE_CARD_VAULT, paymentRecovery);
     }
 
     @Override

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentPresenter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentPresenter.java
@@ -38,7 +38,6 @@ import com.mercadopago.android.px.internal.viewmodel.mappers.SummaryInfoMapper;
 import com.mercadopago.android.px.internal.viewmodel.mappers.SummaryViewModelMapper;
 import com.mercadopago.android.px.model.AmountConfiguration;
 import com.mercadopago.android.px.model.Card;
-import com.mercadopago.android.px.model.CardMetadata;
 import com.mercadopago.android.px.model.DiscountConfigurationModel;
 import com.mercadopago.android.px.model.ExpressMetadata;
 import com.mercadopago.android.px.model.IPaymentDescriptor;
@@ -243,7 +242,8 @@ import java.util.Set;
 
         if (expressMetadata.isCard() || expressMetadata.isConsumerCredits()) {
             payerCost = amountConfiguration
-               .getCurrentPayerCost(splitSelectionState.userWantsToSplit(), payerCostSelection.get(paymentMethodIndex));
+                .getCurrentPayerCost(splitSelectionState.userWantsToSplit(),
+                    payerCostSelection.get(paymentMethodIndex));
         }
 
         final boolean splitPayment = splitSelectionState.userWantsToSplit() && amountConfiguration.allowSplit();
@@ -303,7 +303,7 @@ import java.util.Set;
     @Override
     public void onCvvRequired(@NonNull final Card card) {
         cancelLoading();
-        getView().showCardFlow(card);
+        getView().showSecurityCodeScreen(card);
     }
 
     @Override
@@ -373,7 +373,8 @@ import java.util.Set;
     @Override
     public void onPayerCostSelected(final PayerCost payerCostSelected) {
         final ExpressMetadata expressMetadata = expressMetadataList.get(paymentMethodIndex);
-        final String customOptionId = expressMetadata.isCard() ? expressMetadata.getCard().getId() : expressMetadata.getPaymentMethodId();
+        final String customOptionId =
+            expressMetadata.isCard() ? expressMetadata.getCard().getId() : expressMetadata.getPaymentMethodId();
         final int selected = amountConfigurationRepository.getConfigurationFor(customOptionId)
             .getAppliedPayerCost(splitSelectionState.userWantsToSplit())
             .indexOf(payerCostSelected);

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmActivity.java
@@ -439,7 +439,7 @@ public final class ReviewAndConfirmActivity extends PXActivity<ReviewAndConfirmP
     // Opens Card vault with recovery info.
     @Override
     public void startPaymentRecoveryFlow(final PaymentRecovery recovery) {
-        CardVaultActivity.startActivity(this, REQ_CARD_VAULT, recovery);
+        CardVaultActivity.startActivityForRecovery(this, REQ_CARD_VAULT, recovery);
     }
 
     @Override


### PR DESCRIPTION
Se modifica el flujo para mostrar la pantalla de security code para tarjetas guardadas desde one tap.

* Antes el flujo pasaba por CardVaultActivity
* Ahora va directo de ExpressPaymentFragment a SecurityCodeActivity