### PR TITLE
[feature] Added payment method index tracking

### DIFF
--- a/gradle/deploy_base.gradle
+++ b/gradle/deploy_base.gradle
@@ -34,11 +34,15 @@ task androidSourcesJar(type:Jar) {
     from android.sourceSets.main.java.sourceFiles
 }
 
-task publishAar {
-    finalizedBy 'bintrayUpload'
-
+task publishAar(dependsOn: bintrayUpload) {
     doLast {
-        println 'Deploying ' + project.name + ' version: ' + versionToDeploy
+        println "Deployed ${project.name} version: ${versionToDeploy}"
+    }
+}
+
+task publishLocal(dependsOn: publishToMavenLocal) {
+    doLast {
+        println "Deployed ${project.name} version: ${versionToDeploy}"
     }
 }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentPresenter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentPresenter.java
@@ -247,7 +247,7 @@ import java.util.Set;
         }
 
         final boolean splitPayment = splitSelectionState.userWantsToSplit() && amountConfiguration.allowSplit();
-        ConfirmEvent.from(mercadoPagoESC.getESCCardIds(), expressMetadata, payerCost, splitPayment).track();
+        ConfirmEvent.from(mercadoPagoESC.getESCCardIds(), expressMetadata, payerCost, splitPayment, paymentMethodIndex).track();
 
         paymentRepository.startExpressPayment(expressMetadata, payerCost, splitPayment);
     }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/tracking/internal/events/ConfirmEvent.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/tracking/internal/events/ConfirmEvent.java
@@ -32,8 +32,8 @@ public final class ConfirmEvent extends EventTracker {
     public static ConfirmEvent from(@NonNull final Set<String> cardsWithEsc,
         @NonNull final ExpressMetadata expressMetadata,
         @Nullable final PayerCost selectedPayerCost,
-        final boolean isSplit) {
-        return new ConfirmEvent(new ConfirmData(ReviewType.ONE_TAP,
+        final boolean isSplit, final int paymentMethodSelectedIndex) {
+        return new ConfirmEvent(new ConfirmData(ReviewType.ONE_TAP, paymentMethodSelectedIndex,
             new FromSelectedExpressMetadataToAvailableMethods(cardsWithEsc, selectedPayerCost,isSplit).map(expressMetadata)));
     }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/tracking/internal/model/ConfirmData.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/tracking/internal/model/ConfirmData.java
@@ -9,6 +9,14 @@ import com.mercadopago.android.px.tracking.internal.events.ConfirmEvent;
 public class ConfirmData extends AvailableMethod {
 
     private final String reviewType;
+    private int paymentMethodSelectedIndex;
+
+    public ConfirmData(@NonNull final ConfirmEvent.ReviewType reviewType, final int paymentMethodSelectedIndex,
+        @NonNull final AvailableMethod availableMethod) {
+        super(availableMethod.paymentMethodId, availableMethod.paymentMethodType, availableMethod.extraInfo);
+        this.reviewType = reviewType.value;
+        this.paymentMethodSelectedIndex = paymentMethodSelectedIndex;
+    }
 
     public ConfirmData(@NonNull final ConfirmEvent.ReviewType reviewType,
         @NonNull final AvailableMethod availableMethod) {

--- a/px-checkout/src/main/java/com/mercadopago/android/px/tracking/internal/model/SelectMethodData.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/tracking/internal/model/SelectMethodData.java
@@ -12,6 +12,7 @@ public class SelectMethodData extends TrackingMapModel {
     @NonNull private final List<AvailableMethod> availableMethods;
     @NonNull private final List<ItemInfo> items;
     @NonNull private final BigDecimal preferenceAmount;
+    private final int availableMethodsQuantity;
 
     public SelectMethodData(@NonNull final List<AvailableMethod> availableMethods,
         @NonNull final List<ItemInfo> items,
@@ -19,5 +20,6 @@ public class SelectMethodData extends TrackingMapModel {
         this.availableMethods = availableMethods;
         this.items = items;
         preferenceAmount = totalAmount;
+        availableMethodsQuantity = availableMethods.size();
     }
 }

--- a/px-checkout/src/test/java/com/mercadopago/android/px/tracking/internal/events/ConfirmEventTest.java
+++ b/px-checkout/src/test/java/com/mercadopago/android/px/tracking/internal/events/ConfirmEventTest.java
@@ -24,14 +24,15 @@ public class ConfirmEventTest {
         "{payment_method_type=credit_card, payment_method_id=visa, extra_info={issuer_id=0.0, has_split=false, card_id=123, selected_installment={quantity=1.0, installment_amount=10.0, visible_total_price=10.0, interest_rate=10.0}, has_esc=false}, review_type=one_tap}";
     private static final String EXPECTED_JUST_AM =
         "{payment_method_type=account_money, payment_method_id=account_money, extra_info={balance=10.0, invested=true}, review_type=one_tap}";
+    private static final int PAYMENT_METHOD_SELECTED_INDEX = 2;
 
     @Mock private ExpressMetadata expressMetadata;
     @Mock private Set<String> cardIdsWithEsc;
 
     @Test
     public void whenGetEventPathVerifyIsCorrect() {
-        final ConfirmEvent event = ConfirmEvent.from(cardIdsWithEsc, expressMetadata, mock(PayerCost.class),
-            false);
+        final ConfirmEvent event = ConfirmEvent
+            .from(cardIdsWithEsc, expressMetadata, mock(PayerCost.class), false, PAYMENT_METHOD_SELECTED_INDEX);
         assertEquals(EXPECTED_PATH, event.getEventPath());
     }
 
@@ -43,7 +44,8 @@ public class ConfirmEventTest {
         when(expressMetadata.getAccountMoney()).thenReturn(am);
         when(am.getBalance()).thenReturn(BigDecimal.TEN);
         when(am.isInvested()).thenReturn(true);
-        final ConfirmEvent event = ConfirmEvent.from(cardIdsWithEsc, expressMetadata, mock(PayerCost.class), false);
+        final ConfirmEvent event = ConfirmEvent
+            .from(cardIdsWithEsc, expressMetadata, mock(PayerCost.class), false, PAYMENT_METHOD_SELECTED_INDEX);
         assertEquals(EXPECTED_JUST_AM, event.getEventData().toString());
     }
 
@@ -65,7 +67,8 @@ public class ConfirmEventTest {
         when(expressMetadata.getCard()).thenReturn(card);
         when(expressMetadata.isCard()).thenReturn(true);
 
-        final ConfirmEvent event = ConfirmEvent.from(cardIdsWithEsc, expressMetadata, payerCost, false);
+        final ConfirmEvent event =
+            ConfirmEvent.from(cardIdsWithEsc, expressMetadata, payerCost, false, PAYMENT_METHOD_SELECTED_INDEX);
 
         assertEquals(EXPECTED_JUST_CARD, event.getEventData().toString());
     }

--- a/px-checkout/src/test/java/com/mercadopago/android/px/tracking/internal/events/ConfirmEventTest.java
+++ b/px-checkout/src/test/java/com/mercadopago/android/px/tracking/internal/events/ConfirmEventTest.java
@@ -21,9 +21,9 @@ public class ConfirmEventTest {
 
     private static final String EXPECTED_PATH = "/px_checkout/review/confirm";
     private static final String EXPECTED_JUST_CARD =
-        "{payment_method_type=credit_card, payment_method_id=visa, extra_info={issuer_id=0.0, has_split=false, card_id=123, selected_installment={quantity=1.0, installment_amount=10.0, visible_total_price=10.0, interest_rate=10.0}, has_esc=false}, review_type=one_tap}";
+        "{payment_method_type=credit_card, payment_method_id=visa, extra_info={issuer_id=0.0, has_split=false, card_id=123, selected_installment={quantity=1.0, installment_amount=10.0, visible_total_price=10.0, interest_rate=10.0}, has_esc=false}, payment_method_selected_index=2.0, review_type=one_tap}";
     private static final String EXPECTED_JUST_AM =
-        "{payment_method_type=account_money, payment_method_id=account_money, extra_info={balance=10.0, invested=true}, review_type=one_tap}";
+        "{payment_method_type=account_money, payment_method_id=account_money, extra_info={balance=10.0, invested=true}, payment_method_selected_index=2.0, review_type=one_tap}";
     private static final int PAYMENT_METHOD_SELECTED_INDEX = 2;
 
     @Mock private ExpressMetadata expressMetadata;

--- a/px-checkout/src/test/java/com/mercadopago/android/px/tracking/internal/views/OneTapViewTest.java
+++ b/px-checkout/src/test/java/com/mercadopago/android/px/tracking/internal/views/OneTapViewTest.java
@@ -51,6 +51,7 @@ public class OneTapViewTest {
         final Map<String, Object> data = new HashMap<>();
         data.put("discount", JsonUtil.getInstance().fromJson("{}", DiscountInfo.class).toMap());
         data.put("available_methods", Collections.EMPTY_LIST);
+        data.put("available_methods_quantity", 0.0);
         data.put("items", Collections.EMPTY_LIST);
         data.put("flow", null);
         data.put("preference_amount", null);

--- a/px-checkout/src/test/java/com/mercadopago/android/px/tracking/internal/views/SelectMethodViewTest.java
+++ b/px-checkout/src/test/java/com/mercadopago/android/px/tracking/internal/views/SelectMethodViewTest.java
@@ -25,16 +25,16 @@ public class SelectMethodViewTest {
     private static final String EXPECTED_PATH = "/px_checkout/payments/select_method";
 
     private static final String EXPECTED_ONE_CARD_SAVED_WITH_ESC =
-        "{available_methods=[{payment_method_id=visa, payment_method_type=credit_card, extra_info={issuer_id=null, card_id=123456, selected_installment=null, has_esc=true}}], items=[{quantity=1.0, item={id=1234, description=description, price=10.0}}], preference_amount=10.0}";
+        "{available_methods=[{payment_method_id=visa, payment_method_type=credit_card, extra_info={issuer_id=null, card_id=123456, selected_installment=null, has_esc=true}}], available_methods_quantity=1.0, items=[{quantity=1.0, item={id=1234, description=description, price=10.0}}], preference_amount=10.0}";
 
     private static final String EXPECTED_ONE_CARD_SAVED_NO_ESC =
-        "{available_methods=[{payment_method_id=visa, payment_method_type=credit_card, extra_info={issuer_id=null, card_id=123456, selected_installment=null, has_esc=false}}], items=[{quantity=1.0, item={id=1234, description=description, price=10.0}}], preference_amount=10.0}";
+        "{available_methods=[{payment_method_id=visa, payment_method_type=credit_card, extra_info={issuer_id=null, card_id=123456, selected_installment=null, has_esc=false}}], available_methods_quantity=1.0, items=[{quantity=1.0, item={id=1234, description=description, price=10.0}}], preference_amount=10.0}";
 
     private static final String EXPECTED_JUST_ACCOUNT_MONEY =
-        "{available_methods=[{payment_method_id=account_money, payment_method_type=account_money, extra_info=null}], items=[{quantity=1.0, item={id=1234, description=description, price=10.0}}], preference_amount=10.0}";
+        "{available_methods=[{payment_method_id=account_money, payment_method_type=account_money, extra_info=null}], available_methods_quantity=1.0, items=[{quantity=1.0, item={id=1234, description=description, price=10.0}}], preference_amount=10.0}";
 
     private static final String EXPECTED_JUST_ONE_GROUP =
-        "{available_methods=[{payment_method_id=null, payment_method_type=cards, extra_info=null}], items=[{quantity=1.0, item={id=1234, description=description, price=10.0}}], preference_amount=10.0}";
+        "{available_methods=[{payment_method_id=null, payment_method_type=cards, extra_info=null}], available_methods_quantity=1.0, items=[{quantity=1.0, item={id=1234, description=description, price=10.0}}], preference_amount=10.0}";
 
     private static final String CARD_ID = "123456";
 


### PR DESCRIPTION
Se agrega el trackeo de la posición del medio de pago seleccionado en Express Payment.

## Motivación y Contexto
Optimizar las queries en el análisis de la info obtenida en los tracks.

## Descripción
En el Confirm event se agregó el atributo paymentMethodSelectedIndex. 

## Cómo probarlo
Realizar un pago con Express Payment y observar en el log del track que el atributo es correcto.
<!--- Para bug fixes: Describir cómo reproducir el comportamiento que generaba el bug -->
<!--- Para nuevos features: Se debe agregar el caso de uso a la app de ejemplos, y aquí se debe describir qué función de la app de ejemplos probar -->
