### PR TITLE
[enhancement] add collector id in CheckoutPreference

### DIFF
--- a/px-services/src/main/java/com/mercadopago/android/px/preferences/CheckoutPreference.java
+++ b/px-services/src/main/java/com/mercadopago/android/px/preferences/CheckoutPreference.java
@@ -53,6 +53,8 @@ public class CheckoutPreference implements Serializable {
 
     @Nullable private final Date expirationDateFrom;
 
+    @Nullable private final String collectorId;
+
     @NonNull private final String marketplace;
 
     //region support external integrations - payment processor instores
@@ -92,6 +94,7 @@ public class CheckoutPreference implements Serializable {
         isBinaryMode = builder.isBinaryMode;
         additionalInfo = builder.additionalInfo;
         processingModes = builder.processingModes;
+        collectorId = null;
 
         branchId = builder.branchId;
         paymentPreference = new PaymentPreference();
@@ -207,6 +210,11 @@ public class CheckoutPreference implements Serializable {
     }
 
     @Nullable
+    public String getCollectorId() {
+        return collectorId;
+    }
+
+    @Nullable
     public String getDefaultPaymentMethodId() {
         return getPaymentPreference().getDefaultPaymentMethodId();
     }
@@ -268,6 +276,7 @@ public class CheckoutPreference implements Serializable {
         return isBinaryMode;
     }
 
+    @NonNull
     @Override
     public String toString() {
         return "CheckoutPreference{" +
@@ -570,13 +579,12 @@ public class CheckoutPreference implements Serializable {
         /**
          * Processing mode allowed for this payment. Can be any of {@link ProcessingMode} values.
          *
-         * @param processingMode allowed for this payment preference.
+         * @param processingModes allowed for this payment preference.
          */
         public Builder setProcessingModes(@NonNull final ProcessingMode[] processingModes) {
             this.processingModes = processingModes;
             return this;
         }
-
 
         /**
          * It creates the checkout preference.


### PR DESCRIPTION
Se agrega el collector Id a la clase CheckoutPreference debido a que hay integradores que necesitan saber este dato al momento de realizar el pago.

El collectorId es un atributo que ya viene en la CheckoutPreference de meli.