### PR TITLE
[fix] check session state to exit gracefully

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/base/PXActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/base/PXActivity.java
@@ -2,14 +2,32 @@ package com.mercadopago.android.px.internal.base;
 
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
+import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import com.mercadopago.android.px.R;
+import com.mercadopago.android.px.internal.di.Session;
 
 public abstract class PXActivity<P extends BasePresenter> extends AppCompatActivity implements MvpView {
 
     protected static final String BUNDLE_CREATED = "bundle_created";
 
     protected P presenter;
+
+    @Override
+    protected final void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (!Session.getInstance().isInitialized()) {
+            finish();
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (presenter != null) {
+            presenter.detachView();
+        }
+    }
 
     @CallSuper
     @Override

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/di/Session.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/di/Session.java
@@ -82,6 +82,8 @@ public final class Session extends ApplicationModule implements AmountComponent 
     @SuppressLint("StaticFieldLeak")
     private static Session instance;
 
+    private boolean initialized = false;
+
     // mem cache - lazy init.
     private ConfigurationModule configurationModule;
     private DiscountRepository discountRepository;
@@ -154,6 +156,12 @@ public final class Session extends ApplicationModule implements AmountComponent 
         paymentSetting.configure(paymentConfiguration);
         resolvePreference(mercadoPagoCheckout, paymentSetting);
         // end Store persistent paymentSetting
+
+        initialized = true;
+    }
+
+    public boolean isInitialized(){
+        return initialized;
     }
 
     private void resolvePreference(@NonNull final MercadoPagoCheckout mercadoPagoCheckout,
@@ -188,6 +196,7 @@ public final class Session extends ApplicationModule implements AmountComponent 
         checkoutPreferenceRepository = null;
         paymentMethodsRepository = null;
         paymentRewardRepository = null;
+        initialized = false;
     }
 
     public GroupsRepository getGroupsRepository() {

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/ErrorActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/ErrorActivity.java
@@ -25,8 +25,8 @@ public class ErrorActivity extends PXActivity {
     private String message;
 
     @Override
-    protected void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         animateErrorScreenLaunch();
         setContentView(R.layout.px_activity_error);
         error = (MercadoPagoError) getIntent().getSerializableExtra(EXTRA_ERROR);

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/IssuersActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/IssuersActivity.java
@@ -90,8 +90,8 @@ public class IssuersActivity extends PXActivity<IssuersPresenter> implements Iss
     protected ViewGroup mProgressLayout;
 
     @Override
-    public void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    public void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         getActivityParameters();
 
         presenter.attachView(this);

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/PaymentTypesActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/PaymentTypesActivity.java
@@ -71,8 +71,8 @@ public class PaymentTypesActivity extends PXActivity implements PaymentTypesActi
     }
 
     @Override
-    public void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    public void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         if (mPresenter == null) {
             mPresenter = new PaymentTypesPresenter();
         }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/SecurityCodeActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/SecurityCodeActivity.java
@@ -96,8 +96,8 @@ public class SecurityCodeActivity extends PXActivity<SecurityCodePresenter> impl
     }
 
     @Override
-    public void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    public void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
 
         final Session session = Session.getInstance();
         final PaymentSettingRepository paymentSettings = session.getConfigurationModule().getPaymentSettings();
@@ -129,12 +129,6 @@ public class SecurityCodeActivity extends PXActivity<SecurityCodePresenter> impl
         presenter.storeInBundle(outState);
 
         super.onSaveInstanceState(outState);
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        presenter.detachView();
     }
 
     @Override

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/TermsAndConditionsActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/TermsAndConditionsActivity.java
@@ -31,8 +31,8 @@ public class TermsAndConditionsActivity extends PXActivity {
     private String data;
 
     @Override
-    protected void onCreate(@Nullable final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onPostCreate(@Nullable final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         setContentView(R.layout.px_activity_terms_and_conditions);
 
         data = getIntent().getStringExtra(EXTRA_DATA);

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/bank_deal_detail/BankDealDetailActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/bank_deal_detail/BankDealDetailActivity.java
@@ -25,8 +25,8 @@ public class BankDealDetailActivity extends PXActivity<BankDealDetailPresenter> 
     private TextView logoName;
 
     @Override
-    protected void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         setContentView(R.layout.px_activity_bank_deal_detail);
         createPresenter();
         initializeControls();

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/bank_deals/BankDealsActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/bank_deals/BankDealsActivity.java
@@ -36,8 +36,8 @@ public class BankDealsActivity extends PXActivity<BankDealsPresenter> implements
     protected Toolbar toolbar;
 
     @Override
-    protected void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         setContentView(R.layout.px_activity_bank_deals);
         initializeControls();
         createPresenter();

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/business_result/BusinessPaymentResultActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/business_result/BusinessPaymentResultActivity.java
@@ -37,8 +37,8 @@ public class BusinessPaymentResultActivity extends PXActivity<BusinessPaymentRes
     }
 
     @Override
-    protected void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         setContentView(R.layout.px_activity_payment_result);
 
         presenter = createPresenter();
@@ -70,12 +70,6 @@ public class BusinessPaymentResultActivity extends PXActivity<BusinessPaymentRes
     @Override
     public void onBackPressed() {
         presenter.onAbort();
-    }
-
-    @Override
-    protected void onDestroy() {
-        presenter.detachView();
-        super.onDestroy();
     }
 
     @Override

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/cardvault/CardVaultActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/cardvault/CardVaultActivity.java
@@ -79,8 +79,8 @@ public class CardVaultActivity extends PXActivity<CardVaultPresenter> implements
     }
 
     @Override
-    protected void onCreate(@Nullable final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onPostCreate(@Nullable final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         setContentView(R.layout.px_activity_card_vault);
         configure();
 
@@ -98,12 +98,6 @@ public class CardVaultActivity extends PXActivity<CardVaultPresenter> implements
         } else {
             restoreInstanceState(savedInstanceState);
         }
-    }
-
-    @Override
-    protected void onDestroy() {
-        presenter.detachView();
-        super.onDestroy();
     }
 
     public void restoreInstanceState(final Bundle savedInstanceState) {

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutActivity.java
@@ -78,8 +78,8 @@ public class CheckoutActivity extends PXActivity<CheckoutPresenter>
     }
 
     @Override
-    protected void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         setContentView(R.layout.px_activity_checkout);
         if (savedInstanceState == null) {
             initPresenter();
@@ -484,15 +484,6 @@ public class CheckoutActivity extends PXActivity<CheckoutPresenter>
         overrideTransitionOut();
         overrideTransitionIn();
         PaymentProcessorActivity.start(this, REQ_PAYMENT_PROCESSOR);
-    }
-
-    @Override
-    protected void onDestroy() {
-        //TODO remove null check after session is persisted
-        if (presenter != null) {
-            presenter.detachView();
-        }
-        super.onDestroy();
     }
 
     @Override

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/GuessingCardActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/GuessingCardActivity.java
@@ -194,8 +194,8 @@ public class GuessingCardActivity extends PXActivity<GuessingCardPresenter> impl
     }
 
     @Override
-    public void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    public void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         mActivityActive = true;
         mButtonContainerMustBeShown = true;
         analizeLowRes();
@@ -212,7 +212,6 @@ public class GuessingCardActivity extends PXActivity<GuessingCardPresenter> impl
     @Override
     protected void onDestroy() {
         mActivityActive = false;
-        presenter.detachView();
         super.onDestroy();
     }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/card_association_result/CardAssociationResultErrorActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/card_association_result/CardAssociationResultErrorActivity.java
@@ -5,15 +5,15 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
 import com.mercadolibre.android.ui.widgets.MeliButton;
 import com.mercadopago.android.px.R;
 import com.mercadopago.android.px.core.internal.MercadoPagoCardStorage;
+import com.mercadopago.android.px.internal.base.PXActivity;
 import com.mercadopago.android.px.internal.features.guessing_card.GuessingCardActivity;
 import com.mercadopago.android.px.internal.util.ViewUtils;
 import com.mercadopago.android.px.tracking.internal.views.CardAssociationResultViewTrack;
 
-public class CardAssociationResultErrorActivity extends AppCompatActivity {
+public class CardAssociationResultErrorActivity extends PXActivity {
     private static final String PARAM_ACCESS_TOKEN = "accessToken";
     private static final String PARAM_MERCADO_PAGO_CARD_STORAGE = "mercadoPagoCardStorage";
 
@@ -28,8 +28,8 @@ public class CardAssociationResultErrorActivity extends AppCompatActivity {
     }
 
     @Override
-    public void onCreate(@Nullable final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    public void onPostCreate(@Nullable final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
 
         final Intent intent = getIntent();
         accessToken = intent.getStringExtra(PARAM_ACCESS_TOKEN);

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/card_association_result/CardAssociationResultSuccessActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/guessing_card/card_association_result/CardAssociationResultSuccessActivity.java
@@ -5,13 +5,13 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
 import com.mercadolibre.android.ui.widgets.MeliButton;
 import com.mercadopago.android.px.R;
+import com.mercadopago.android.px.internal.base.PXActivity;
 import com.mercadopago.android.px.internal.util.ViewUtils;
 import com.mercadopago.android.px.tracking.internal.views.CardAssociationResultViewTrack;
 
-public class CardAssociationResultSuccessActivity extends AppCompatActivity {
+public class CardAssociationResultSuccessActivity extends PXActivity {
 
     public static void startCardAssociationResultSuccessActivity(final Activity callerActivity) {
         final Intent intent = new Intent(callerActivity, CardAssociationResultSuccessActivity.class);
@@ -20,8 +20,8 @@ public class CardAssociationResultSuccessActivity extends AppCompatActivity {
     }
 
     @Override
-    public void onCreate(@Nullable final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    public void onPostCreate(@Nullable final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
 
         setContentView(R.layout.px_card_association_result_success);
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/installments/InstallmentsActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/installments/InstallmentsActivity.java
@@ -76,8 +76,8 @@ public class InstallmentsActivity extends PXActivity<InstallmentsPresenter> impl
     }
 
     @Override
-    public void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    public void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
 
         final Session session = Session.getInstance();
         final ConfigurationModule configurationModule = session.getConfigurationModule();

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payer_information/PayerInformationActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payer_information/PayerInformationActivity.java
@@ -85,8 +85,8 @@ public class PayerInformationActivity extends PXActivity<PayerInformationPresent
     }
 
     @Override
-    protected void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         mActivityActive = true;
         analyzeLowRes();
         setContentView();

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_methods/PaymentMethodsActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_methods/PaymentMethodsActivity.java
@@ -45,8 +45,8 @@ public class PaymentMethodsActivity extends PXActivity<PaymentMethodsPresenter> 
     }
 
     @Override
-    protected void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
 
         final Session session = Session.getInstance();
         mPresenter =

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_result/PaymentResultActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_result/PaymentResultActivity.java
@@ -54,8 +54,8 @@ public class PaymentResultActivity extends PXActivity<PaymentResultPresenter> im
     }
 
     @Override
-    protected void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         setContentView(R.layout.px_activity_payment_result);
 
         presenter = createPresenter();
@@ -72,12 +72,6 @@ public class PaymentResultActivity extends PXActivity<PaymentResultPresenter> im
 
         return new PaymentResultPresenter(session.getConfigurationModule().getPaymentSettings(),
             session.getInstructionsRepository(), paymentModel);
-    }
-
-    @Override
-    protected void onDestroy() {
-        presenter.detachView();
-        super.onDestroy();
     }
 
     @Override

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_vault/PaymentVaultActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_vault/PaymentVaultActivity.java
@@ -101,8 +101,8 @@ public class PaymentVaultActivity extends PXActivity<PaymentVaultPresenter> impl
     }
 
     @Override
-    protected void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         final Session session = Session.getInstance();
         final PaymentSettingRepository configuration = session.getConfigurationModule().getPaymentSettings();
         presenter = new PaymentVaultPresenter(configuration,
@@ -411,7 +411,6 @@ public class PaymentVaultActivity extends PXActivity<PaymentVaultPresenter> impl
     @Override
     protected void onDestroy() {
         mActivityActive = false;
-        presenter.detachView();
         super.onDestroy();
     }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/plugins/PaymentProcessorActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/plugins/PaymentProcessorActivity.java
@@ -9,12 +9,12 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
-import android.support.v7.app.AppCompatActivity;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import com.mercadopago.android.px.R;
 import com.mercadopago.android.px.core.PaymentProcessor;
 import com.mercadopago.android.px.core.SplitPaymentProcessor;
+import com.mercadopago.android.px.internal.base.PXActivity;
 import com.mercadopago.android.px.internal.callbacks.PaymentServiceHandler;
 import com.mercadopago.android.px.internal.callbacks.PaymentServiceHandlerWrapper;
 import com.mercadopago.android.px.internal.datasource.EscPaymentManagerImp;
@@ -40,7 +40,7 @@ import static com.mercadopago.android.px.internal.features.Constants.RESULT_FAIL
 import static com.mercadopago.android.px.internal.features.Constants.RESULT_PAYMENT;
 import static com.mercadopago.android.px.internal.util.ErrorUtil.ERROR_REQUEST_CODE;
 
-public final class PaymentProcessorActivity extends AppCompatActivity
+public final class PaymentProcessorActivity extends PXActivity
     implements SplitPaymentProcessor.OnPaymentListener,
     PaymentProcessor.OnPaymentListener {
 
@@ -89,8 +89,8 @@ public final class PaymentProcessorActivity extends AppCompatActivity
     }
 
     @Override
-    public void onCreate(@Nullable final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    public void onPostCreate(@Nullable final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
 
         final FrameLayout frameLayout = new FrameLayout(this);
         frameLayout.setId(R.id.px_main_container);

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_and_confirm/ReviewAndConfirmActivity.java
@@ -127,8 +127,8 @@ public final class ReviewAndConfirmActivity extends PXActivity<ReviewAndConfirmP
      * the UI for review and confirm right away, and we can start the recover payment process
      */
     @Override
-    protected void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onPostCreate(final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         setContentView(R.layout.px_view_container_review_and_confirm);
         initializeViews();
         final Session session = Session.getInstance();
@@ -183,15 +183,6 @@ public final class ReviewAndConfirmActivity extends PXActivity<ReviewAndConfirmP
     protected void onResume() {
         super.onResume();
         presenter.onViewResumed(this);
-    }
-
-    @Override
-    protected void onDestroy() {
-        //TODO remove null check after session is persisted
-        if (presenter != null) {
-            presenter.detachView();
-        }
-        super.onDestroy();
     }
 
     /**

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_payment_methods/ReviewPaymentMethodsActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/review_payment_methods/ReviewPaymentMethodsActivity.java
@@ -32,8 +32,8 @@ public class ReviewPaymentMethodsActivity extends PXActivity<ReviewPaymentMethod
     }
 
     @Override
-    protected void onCreate(final Bundle savedInstance) {
-        super.onCreate(savedInstance);
+    protected void onPostCreate(final Bundle savedInstance) {
+        super.onPostCreate(savedInstance);
         setContentView(R.layout.px_activity_review_payment_methods);
         recyclerView = findViewById(R.id.mpsdkReviewPaymentMethodsView);
         final FrameLayout mTryOtherCardButton = findViewById(R.id.tryOtherCardButton);


### PR DESCRIPTION
## Motivación y Contexto
<!--- ¿Por qué este cambio es requerido? ¿Qué problema resuelve? -->
Este cambio resuelve dos problemas:
* Salir del checkout de una forma amigable cuando el estado de la sesión es inconsistente debido a que posiblemente haya muerto el Application
* Algunos memory leaks debido a que no todos los presenters se estaban desvinculando de la vista debidamente.