### PR TITLE
Fix Overscrolling header space

### DIFF
--- a/px-checkout/src/main/res/layout/px_activity_payment_result.xml
+++ b/px-checkout/src/main/res/layout/px_activity_payment_result.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:overScrollMode="never"
     android:fillViewport="true">
 
     <FrameLayout


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
Espacio en blanco cuando se scrollea para abajo en la congrats.

## Descripción
Se agrego el android:overScrollMode="never" para que no permita hacer el bounce al scrollear

## Cómo probarlo
Llegar hasta la congrats y scrollear para arriba y para abajo

