### PR TITLE
Reduce DiscountsBox margins in congrats.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## VERSION 4.34.0
+_28_01_2020_
+* FIX - Reduce margins of MLBusinessDiscountBoxView in congrats.
+
 ## VERSION 4.33.0
 _24_01_2020_
 * FEATURE - Added local behaviour

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## VERSION 4.34.0
+## VERSION 4.33.1
 _28_01_2020_
 * FIX - Reduce margins of MLBusinessDiscountBoxView in congrats.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.parallel=true
 org.gradle.daemon=true
 # Current lib version
-version_to_deploy=4.33.0
+version_to_deploy=4.34.0
 # Compile versions
 build_tools_version=28.0.3
 min_api_level=19

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.parallel=true
 org.gradle.daemon=true
 # Current lib version
-version_to_deploy=4.34.0
+version_to_deploy=4.33.1
 # Compile versions
 build_tools_version=28.0.3
 min_api_level=19

--- a/px-checkout/src/main/res/layout/px_business_components.xml
+++ b/px-checkout/src/main/res/layout/px_business_components.xml
@@ -33,10 +33,10 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_marginTop="@dimen/px_s_margin"
-        android:layout_marginRight="@dimen/px_l_margin"
-        android:layout_marginEnd="@dimen/px_l_margin"
-        android:layout_marginLeft="@dimen/px_l_margin"
-        android:layout_marginStart="@dimen/px_l_margin"/>
+        android:layout_marginRight="@dimen/px_s_margin"
+        android:layout_marginEnd="@dimen/px_s_margin"
+        android:layout_marginLeft="@dimen/px_s_margin"
+        android:layout_marginStart="@dimen/px_s_margin"/>
 
     <com.mercadolibre.android.ui.widgets.MeliButton
         android:id="@+id/showAllDiscounts"


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
Necesitamos este cambio para evitar que las imágenes de los items de descuento se recorten en algunos dispositivos. 

## Descripción
<!--- Describir los cambios en detalle -->
Reducimos los margenes laterales de _MLBusinessDiscountBoxView_ a la mitad.

<!--- ## Cómo probarlo -->
<!--- Para bug fixes: Describir cómo reproducir el comportamiento que generaba el bug -->
<!--- Para nuevos features: Se debe agregar el caso de uso a la app de ejemplos, y aquí se debe describir qué función de la app de ejemplos probar -->

## Screenshots
<!--- Para bug fixes: Incluir screenshots o videos del antes y después -->
<!--- Para nuevos features: Incluir screenshots o videos de la nueva UI -->
Pruebas realizadas en Samsung S7

### Antes

<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73300120-37f4ca00-41ef-11ea-9a56-3442bfbe2538.jpg" width="300" height="500" align="middle"/>
</p>

### Después

<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73300544-f3b5f980-41ef-11ea-88d8-3b509738f83b.png" width="300" height="500" align="middle"/>
</p>



## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->
