### PR TITLE
added fix congrats for discountbox and header for credits-mlb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## VERSION 4.34.0
+_29_01_2020_
+* ENHANCEMENT - Added header for terms and conditions
+* FIX - Reduce margins of MLBusinessDiscountBoxView in congrats.
+
 ## VERSION 4.33.0
 _24_01_2020_
 * FEATURE - Added local behaviour

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.parallel=true
 org.gradle.daemon=true
 # Current lib version
-version_to_deploy=4.33.0
+version_to_deploy=4.34.0
 # Compile versions
 build_tools_version=28.0.3
 min_api_level=19

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/TermsAndConditionsActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/TermsAndConditionsActivity.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import android.webkit.URLUtil;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import com.mercadopago.android.px.BuildConfig;
 import com.mercadopago.android.px.R;
 import com.mercadopago.android.px.internal.base.PXActivity;
 import com.mercadopago.android.px.tracking.internal.views.TermsAndConditionsViewTracker;
@@ -69,6 +70,7 @@ public class TermsAndConditionsActivity extends PXActivity {
         });
 
         if (URLUtil.isValidUrl(data)) {
+            mTermsAndConditionsWebView.getSettings().setUserAgentString("MercadoLibre-Android/"+ BuildConfig.VERSION_NAME);
             mTermsAndConditionsWebView.loadUrl(data);
         } else {
             mTermsAndConditionsWebView.loadData(data, "text/html", "UTF-8");

--- a/px-checkout/src/main/res/layout/px_business_components.xml
+++ b/px-checkout/src/main/res/layout/px_business_components.xml
@@ -33,10 +33,10 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_marginTop="@dimen/px_s_margin"
-        android:layout_marginRight="@dimen/px_l_margin"
-        android:layout_marginEnd="@dimen/px_l_margin"
-        android:layout_marginLeft="@dimen/px_l_margin"
-        android:layout_marginStart="@dimen/px_l_margin"/>
+        android:layout_marginRight="@dimen/px_s_margin"
+        android:layout_marginEnd="@dimen/px_s_margin"
+        android:layout_marginLeft="@dimen/px_s_margin"
+        android:layout_marginStart="@dimen/px_s_margin"/>
 
     <com.mercadolibre.android.ui.widgets.MeliButton
         android:id="@+id/showAllDiscounts"


### PR DESCRIPTION

## Motivación y Contexto
- Necesitamos este cambio para evitar que las imágenes de los items de descuento se recorten en algunos dispositivos.
- Se agregan header para términos y condiciones para que no aparezca el encabezado y el pie de pagina de Meli.

## Descripción
- Reducimos los margenes laterales de MLBusinessDiscountBoxView a la mitad.
- Se agrega header de  User-Agent en formato "MercadoLibre-Android/X.X.X"

## Screenshots
<!--- Para bug fixes: Incluir screenshots o videos del antes y después -->
<!--- Para nuevos features: Incluir screenshots o videos de la nueva UI -->
### Antes

<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73300120-37f4ca00-41ef-11ea-9a56-3442bfbe2538.jpg" width="300" height="500" align="middle"/>
</p>

### Después

<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73300544-f3b5f980-41ef-11ea-88d8-3b509738f83b.png" width="300" height="500" align="middle"/>
</p>

## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [x] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
