### PR TITLE
change width and margin of discount view

### DIFF
--- a/px-checkout/src/main/res/layout/px_business_components.xml
+++ b/px-checkout/src/main/res/layout/px_business_components.xml
@@ -29,14 +29,14 @@
 
     <com.mercadolibre.android.mlbusinesscomponents.components.discount.MLBusinessDiscountBoxView
         android:id="@+id/discountView"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_marginTop="@dimen/px_s_margin"
-        android:layout_marginRight="@dimen/px_s_margin"
-        android:layout_marginEnd="@dimen/px_s_margin"
-        android:layout_marginLeft="@dimen/px_s_margin"
-        android:layout_marginStart="@dimen/px_s_margin"/>
+        android:layout_marginRight="@dimen/px_l_margin"
+        android:layout_marginEnd="@dimen/px_l_margin"
+        android:layout_marginLeft="@dimen/px_l_margin"
+        android:layout_marginStart="@dimen/px_l_margin"/>
 
     <com.mercadolibre.android.ui.widgets.MeliButton
         android:id="@+id/showAllDiscounts"


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
Volvemos a los márgenes originales, cambiamos como se acomoda el componente de descuento a lo largo.

## Descripción
Debido al refactor del componente de descuento debemos volver a los márgenes originales y cambiar de wrap_content a match_parent.

## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [x] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
