### PR TITLE
Fixed card form split animation

### DIFF
--- a/example/src/main/java/com/mercadopago/android/px/utils/OneTapSamples.java
+++ b/example/src/main/java/com/mercadopago/android/px/utils/OneTapSamples.java
@@ -144,7 +144,7 @@ public final class OneTapSamples {
         final PaymentConfiguration paymentConfiguration =
             PaymentConfigurationUtils.create(new SamplePaymentProcessorNoView(payment));
 
-        return new MercadoPagoCheckout.Builder(ONE_TAP_MERCHANT_PUBLIC_KEY, preference, paymentConfiguration)
+        return new MercadoPagoCheckout.Builder(ONE_TAP_DIRECT_DISCOUNT_MERCHANT_PUBLIC_KEY, preference, paymentConfiguration)
             .setPrivateKey(ONE_TAP_PAYER_1_ACCESS_TOKEN)
             .setAdvancedConfiguration(new AdvancedConfiguration.Builder().setExpressPaymentEnable(true).build());
     }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/DefaultPaymentProcessor.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/DefaultPaymentProcessor.java
@@ -59,8 +59,8 @@ public final class DefaultPaymentProcessor implements SplitPaymentProcessor {
     }
 
     @Override
-    public boolean supportsSplitPayment(@NonNull final CheckoutPreference checkoutPreference) {
-        return true;
+    public boolean supportsSplitPayment(@Nullable final CheckoutPreference checkoutPreference) {
+        return false;
     }
 
     @Nullable

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentFragment.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentFragment.java
@@ -188,9 +188,11 @@ public class ExpressPaymentFragment extends Fragment implements ExpressPayment.V
                 fadeOut.setDuration(duration);
 
                 paymentMethodHeaderView.startAnimation(fadeOut);
-                splitPaymentView.startAnimation(fadeOut);
                 indicator.startAnimation(fadeOut);
                 confirmButton.startAnimation(slideDown);
+                if (splitPaymentView.getVisibility() == VISIBLE) {
+                    splitPaymentView.startAnimation(fadeOut);
+                }
 
                 summaryView.animateExit(offset);
             }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/slider/SplitPaymentHeaderAdapter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/slider/SplitPaymentHeaderAdapter.java
@@ -35,6 +35,7 @@ public class SplitPaymentHeaderAdapter extends HubableAdapter<List<SplitPaymentH
     public static final class Empty extends Model {
         @Override
         public void visit(final LabeledSwitch labeledSwitch) {
+            labeledSwitch.clearAnimation();
             labeledSwitch.setVisibility(View.GONE);
         }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/slider/ViewAdapter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/slider/ViewAdapter.java
@@ -4,8 +4,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.View;
 import com.mercadopago.android.px.internal.viewmodel.SplitSelectionState;
-import java.util.Collections;
-import java.util.List;
 
 public abstract class ViewAdapter<T, V extends View> {
 


### PR DESCRIPTION
- Se saca el true de que soportamos split en la procesadora default.
- La view de split se mostraba cuando no debía en algunos casos después de la animación del alta nuevo.

- También le puse descuento always on al merchant que lo tenía antes, y lo dejé para el ejemplo uno de one tap.