### PR TITLE
[FIX] fixed nullpointer in cardform

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutActivity.java
@@ -228,17 +228,13 @@ public class CheckoutActivity extends PXActivity<CheckoutPresenter>
 
         final FragmentManager supportFragmentManager = getSupportFragmentManager();
 
-        Fragment fragment = supportFragmentManager.findFragmentByTag(TAG_ONETAP_FRAGMENT);
-
-        if (fragment == null) {
-            fragment = ExpressPaymentFragment.getInstance();
+        if (supportFragmentManager.findFragmentByTag(TAG_ONETAP_FRAGMENT) == null) {
+            supportFragmentManager
+                .beginTransaction()
+                .setCustomAnimations(R.anim.px_slide_right_to_left_in, R.anim.px_slide_right_to_left_out)
+                .replace(R.id.one_tap_fragment, ExpressPaymentFragment.getInstance(), TAG_ONETAP_FRAGMENT)
+                .commitNowAllowingStateLoss();
         }
-
-        getSupportFragmentManager()
-            .beginTransaction()
-            .setCustomAnimations(R.anim.px_slide_right_to_left_in, R.anim.px_slide_right_to_left_out)
-            .replace(R.id.one_tap_fragment, fragment, TAG_ONETAP_FRAGMENT)
-            .commitNowAllowingStateLoss();
     }
 
     @Override


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
Bug que hacía romper el nuevo alta de tarjeta.

## Descripción

Al tener destroy-activities el método showOneTap se llamaba siempre, haciendo que el fragment de OneTap se agregue nuevamente al stack. Entonces sí CardForm estaba en el tope de la pila, este pasaba en segundo lugar al agregar nuevamente OneTap.

Link Bugsnag: https://app.bugsnag.com/mercadolibre/mercado-pago-android/errors?filters[event.since][0][type]=eq&filters[event.since][0][value]=all&filters[app.release_stage][0][type]=eq&filters[app.release_stage][0][value]=production&filters[event.severity][0][type]=eq&filters[event.severity][0][value]=error&filters[search][0][type]=eq&filters[search][0][value]=cardform&filters[search][1][type]=eq&filters[search][1][value]=NullPointerException&filters[error.status][0][type]=eq&filters[error.status][0][value]=open&sort=users

## Cómo probarlo

Teniendo destroy activity, ingresar a card-form, ir y volviendo de background, querer pagar con otro medio de pago.

## Tipo de cambio (para el release manager)
- [x] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
