### PR TITLE
[Fix] Last four digits null after cvv remedy

### DIFF
--- a/example/src/main/java/com/mercadopago/SamplePaymentProcessor.java
+++ b/example/src/main/java/com/mercadopago/SamplePaymentProcessor.java
@@ -1,13 +1,13 @@
 package com.mercadopago;
 
 import android.content.Context;
-import android.os.Bundle;
 import android.os.Parcel;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import com.mercadopago.android.px.model.BusinessPayment;
 import com.mercadopago.android.px.model.IPayment;
+import com.mercadopago.android.px.model.IPaymentDescriptor;
 import com.mercadopago.android.px.model.internal.IParcelablePaymentDescriptor;
 import com.mercadopago.android.px.preferences.CheckoutPreference;
 
@@ -55,6 +55,8 @@ public class SamplePaymentProcessor extends SamplePaymentProcessorNoView {
     @Nullable
     @Override
     public Fragment getFragment(@NonNull final CheckoutData data, @NonNull final Context context) {
-        return SamplePaymentProcessorFragment.with(payment != null ? payment : businessPayment);
+        final IPaymentDescriptor payment = getPayment();
+        return SamplePaymentProcessorFragment.with(payment instanceof BusinessPayment ? (BusinessPayment) payment :
+            (IParcelablePaymentDescriptor) payment);
     }
 }

--- a/example/src/main/java/com/mercadopago/SamplePaymentProcessorNoView.java
+++ b/example/src/main/java/com/mercadopago/SamplePaymentProcessorNoView.java
@@ -5,13 +5,15 @@ import android.os.Handler;
 import android.os.Parcel;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.Size;
 import android.support.v4.app.Fragment;
 import com.mercadopago.android.px.core.SplitPaymentProcessor;
-import com.mercadopago.android.px.model.BusinessPayment;
 import com.mercadopago.android.px.model.IPayment;
 import com.mercadopago.android.px.model.IPaymentDescriptor;
 import com.mercadopago.android.px.model.internal.IParcelablePaymentDescriptor;
 import com.mercadopago.android.px.preferences.CheckoutPreference;
+import java.util.Collections;
+import java.util.List;
 
 public class SamplePaymentProcessorNoView implements SplitPaymentProcessor {
 
@@ -30,28 +32,25 @@ public class SamplePaymentProcessorNoView implements SplitPaymentProcessor {
         }
     };
 
-    protected final IParcelablePaymentDescriptor payment;
-    protected final BusinessPayment businessPayment;
+    private int paymentIndex = 0;
+    protected final List<? extends IPaymentDescriptor> payments;
     private final Handler handler = new Handler();
 
     public SamplePaymentProcessorNoView(final IPayment payment) {
-        this.payment = IParcelablePaymentDescriptor.with(payment);
-        businessPayment = null;
+        payments = Collections.singletonList(IParcelablePaymentDescriptor.with(payment));
     }
 
-    public SamplePaymentProcessorNoView(final IParcelablePaymentDescriptor payment) {
-        this.payment = payment;
-        businessPayment = null;
+    public SamplePaymentProcessorNoView(final IPaymentDescriptor payment) {
+        payments = Collections.singletonList(payment);
     }
 
-    public SamplePaymentProcessorNoView(final BusinessPayment businessPayment) {
-        this.businessPayment = businessPayment;
-        payment = null;
+    public SamplePaymentProcessorNoView(@NonNull @Size(min = 1) final List<? extends IPaymentDescriptor> payments) {
+        this.payments = payments;
     }
 
     /* default */ SamplePaymentProcessorNoView(final Parcel in) {
-        payment = in.readParcelable(IParcelablePaymentDescriptor.class.getClassLoader());
-        businessPayment = in.readParcelable(BusinessPayment.class.getClassLoader());
+        //Not used as parcel
+        payments = null;
     }
 
     @Override
@@ -71,7 +70,7 @@ public class SamplePaymentProcessorNoView implements SplitPaymentProcessor {
     }
 
     @Override
-    public boolean supportsSplitPayment(@NonNull final CheckoutPreference checkoutPreference) {
+    public boolean supportsSplitPayment(@Nullable final CheckoutPreference checkoutPreference) {
         return true;
     }
 
@@ -88,16 +87,14 @@ public class SamplePaymentProcessorNoView implements SplitPaymentProcessor {
 
     @Override
     public void writeToParcel(final Parcel dest, final int flags) {
-        dest.writeParcelable(payment, flags);
-        dest.writeParcelable(businessPayment, flags);
+        //Not used as parcel
     }
 
     @NonNull
-    private IPaymentDescriptor getPayment() {
-        if (payment != null) {
-            return payment;
-        } else {
-            return businessPayment;
+    protected IPaymentDescriptor getPayment() {
+        if (paymentIndex >= payments.size()) {
+            paymentIndex = 0;
         }
+        return payments.get(paymentIndex++);
     }
 }

--- a/example/src/main/java/com/mercadopago/android/px/utils/OneTapSamples.java
+++ b/example/src/main/java/com/mercadopago/android/px/utils/OneTapSamples.java
@@ -14,10 +14,13 @@ import com.mercadopago.android.px.model.Payment;
 import com.mercadopago.android.px.model.PaymentTypes;
 import com.mercadopago.android.px.model.Sites;
 import com.mercadopago.android.px.model.commission.PaymentTypeChargeRule;
+import com.mercadopago.android.px.model.internal.IParcelablePaymentDescriptor;
 import com.mercadopago.android.px.preferences.CheckoutPreference;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import static com.mercadopago.android.px.utils.PaymentUtils.getBusinessPaymentApproved;
@@ -136,13 +139,12 @@ public final class OneTapSamples {
 
     // It should suggest one tap with account money
     private static MercadoPagoCheckout.Builder startOneTapWithAccountMoneyNoCards() {
-
-        final GenericPayment payment = getGenericPaymentApproved();
-
         final CheckoutPreference preference =
             getCheckoutPreferenceWithPayerEmail(new ArrayList<>(), 120);
         final PaymentConfiguration paymentConfiguration =
-            PaymentConfigurationUtils.create(new SamplePaymentProcessorNoView(payment));
+            PaymentConfigurationUtils.create(new SamplePaymentProcessorNoView(Arrays.asList(
+                IParcelablePaymentDescriptor.with(getGenericPaymentRejected()),
+                IParcelablePaymentDescriptor.with(getGenericPaymentApproved()))));
 
         return new MercadoPagoCheckout.Builder(ONE_TAP_DIRECT_DISCOUNT_MERCHANT_PUBLIC_KEY, preference, paymentConfiguration)
             .setPrivateKey(ONE_TAP_PAYER_1_ACCESS_TOKEN)

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentPresenter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentPresenter.java
@@ -68,7 +68,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /* default */ class ExpressPaymentPresenter extends BasePresenter<ExpressPayment.View>

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_result/mappers/PaymentResultRemediesModelMapper.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_result/mappers/PaymentResultRemediesModelMapper.kt
@@ -9,14 +9,14 @@ import com.mercadopago.android.px.model.internal.remedies.RemediesResponse
 internal object PaymentResultRemediesModelMapper : Mapper<RemediesResponse, RemediesModel>() {
     override fun map(model: RemediesResponse): RemediesModel {
         return RemediesModel(
-                model.cvv?.let {
-                    it.fieldSetting.run {
-                        CvvRemedy.Model(it.message,
-                                title,
-                                hintMessage,
-                                length)
-                    }
+            model.cvv?.let {
+                it.fieldSetting.run {
+                    CvvRemedy.Model(it.message,
+                            title,
+                            hintMessage,
+                            length)
                 }
+            }
         )
     }
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/util/TokenCreationWrapper.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/util/TokenCreationWrapper.kt
@@ -36,7 +36,7 @@ internal class TokenCreationWrapper private constructor(builder: Builder) {
         return if (card != null) {
             SavedESCCardToken.createWithSecurityCode(card.id, cvv).run {
                 validateSecurityCode(card)
-                createESCToken(this)
+                createESCToken(this).apply { lastFourDigits = card.lastFourDigits }
             }
         } else {
             SavedESCCardToken.createWithSecurityCode(token!!.cardId, cvv).run {


### PR DESCRIPTION
- Decía "Tarjeta terminada en NULL" después de un recupero de los nuevos de CVV.
- La procesadora del example soporta una lista de pagos.