### PR TITLE
[feature] add security type to signature of SplitPaymentProcessor

### DIFF
--- a/px-addons/src/main/java/com/mercadopago/android/px/addons/model/internal/SecurityType.kt
+++ b/px-addons/src/main/java/com/mercadopago/android/px/addons/model/internal/SecurityType.kt
@@ -1,0 +1,6 @@
+package com.mercadopago.android.px.addons.model.internal
+
+enum class SecurityType(val value: String) {
+    SECOND_FACTOR("2fa"),
+    NONE("none")
+}

--- a/px-checkout/src/main/java/com/mercadopago/android/px/core/PaymentProcessor.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/core/PaymentProcessor.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import com.mercadopago.android.px.addons.model.internal.SecurityType;
 import com.mercadopago.android.px.model.BusinessPayment;
 import com.mercadopago.android.px.model.GenericPayment;
 import com.mercadopago.android.px.model.Payment;
@@ -22,12 +23,20 @@ public interface PaymentProcessor extends Serializable {
 
         @NonNull public final PaymentData paymentData;
         @NonNull public final CheckoutPreference checkoutPreference;
+        @NonNull public final String securityType;
 
         @Deprecated
         public CheckoutData(@NonNull final PaymentData paymentData,
             @NonNull final CheckoutPreference checkoutPreference) {
+            this(paymentData, checkoutPreference, SecurityType.NONE.getValue());
+        }
+
+        @Deprecated
+        public CheckoutData(@NonNull final PaymentData paymentData,
+            @NonNull final CheckoutPreference checkoutPreference, @NonNull final String securityType) {
             this.paymentData = paymentData;
             this.checkoutPreference = checkoutPreference;
+            this.securityType = securityType;
         }
     }
 
@@ -47,8 +56,8 @@ public interface PaymentProcessor extends Serializable {
      * Method that we will call if {@link #shouldShowFragmentOnPayment()} is false. we will place a loading for you
      * meanwhile we call this method.
      *
-     * @param data checkout data to the moment it's called.
-     * @param context that you may need to fill information.
+     * @param data            checkout data to the moment it's called.
+     * @param context         that you may need to fill information.
      * @param paymentListener when you have processed your payment you should call {@link OnPaymentListener}
      */
     void startPayment(@NonNull final PaymentProcessor.CheckoutData data, @NonNull final Context context,
@@ -74,7 +83,7 @@ public interface PaymentProcessor extends Serializable {
      * This bundle will be attached to the fragment that you expose in {@link #getFragment(PaymentProcessor.CheckoutData,
      * Context)}
      *
-     * @param data checkout data to the moment it's called.
+     * @param data    checkout data to the moment it's called.
      * @param context that you may need to fill information.
      * @return fragment.
      * @deprecated you can place your bundle in the fragment you provide.
@@ -90,7 +99,7 @@ public interface PaymentProcessor extends Serializable {
      * inside {@link android.support.v4.app.Fragment#onAttach(Context)} context will be an instance of {@link
      * OnPaymentListener}
      *
-     * @param data checkout data to the moment it's called.
+     * @param data    checkout data to the moment it's called.
      * @param context that you may need to fill information.
      * @return fragment
      */

--- a/px-checkout/src/main/java/com/mercadopago/android/px/core/SplitPaymentProcessor.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/core/SplitPaymentProcessor.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 import android.support.v4.app.Fragment;
+import com.mercadopago.android.px.addons.model.internal.SecurityType;
 import com.mercadopago.android.px.model.IPaymentDescriptor;
 import com.mercadopago.android.px.model.PaymentData;
 import com.mercadopago.android.px.model.exceptions.MercadoPagoError;
@@ -19,11 +20,22 @@ public interface SplitPaymentProcessor extends Parcelable {
 
         @NonNull public final CheckoutPreference checkoutPreference;
         @NonNull public final List<PaymentData> paymentDataList;
+        @NonNull public final String securityType;
 
+        /**
+         * @deprecated use the one with security type
+         */
+        @Deprecated
         public CheckoutData(@NonNull @Size(min = 1) final List<PaymentData> paymentData,
             @NonNull final CheckoutPreference checkoutPreference) {
+            this(paymentData, checkoutPreference, SecurityType.NONE.getValue());
+        }
+
+        public CheckoutData(@NonNull @Size(min = 1) final List<PaymentData> paymentData,
+            @NonNull final CheckoutPreference checkoutPreference, @NonNull final String securityType) {
             paymentDataList = paymentData;
             this.checkoutPreference = checkoutPreference;
+            this.securityType = securityType;
         }
     }
 
@@ -31,8 +43,8 @@ public interface SplitPaymentProcessor extends Parcelable {
      * Method that we will call if {@link #shouldShowFragmentOnPayment(CheckoutPreference)} is false. we will place a
      * loading for you meanwhile we call this method.
      *
-     * @param data checkout data to the moment it's called.
-     * @param context that you may need to fill information.
+     * @param data            checkout data to the moment it's called.
+     * @param context         that you may need to fill information.
      * @param paymentListener when you have processed your payment you should call {@link OnPaymentListener}
      */
     void startPayment(@NonNull final Context context, @NonNull final CheckoutData data,
@@ -68,7 +80,7 @@ public interface SplitPaymentProcessor extends Parcelable {
      * inside {@link android.support.v4.app.Fragment#onAttach(Context)} context will be an instance of {@link
      * OnPaymentListener}
      *
-     * @param data checkout data to the moment it's called.
+     * @param data    checkout data to the moment it's called.
      * @param context that you may need to fill information.
      * @return fragment
      */
@@ -85,12 +97,11 @@ public interface SplitPaymentProcessor extends Parcelable {
     interface BackHandler {
 
         /**
-         * The implementation of this method can tell you if the back action is enabled or disabled.
-         * In certain cases you want to block UI, disabling the back button. This occurs for toolbar back button,
-         * display screen back button and swipe back gestures.
+         * The implementation of this method can tell you if the back action is enabled or disabled. In certain cases
+         * you want to block UI, disabling the back button. This occurs for toolbar back button, display screen back
+         * button and swipe back gestures.
          */
         boolean isBackEnabled();
-
     }
 
     /**

--- a/px-checkout/src/main/java/com/mercadopago/android/px/core/internal/CheckoutDataMapper.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/core/internal/CheckoutDataMapper.java
@@ -8,6 +8,6 @@ import com.mercadopago.android.px.internal.viewmodel.mappers.Mapper;
 public class CheckoutDataMapper extends Mapper<SplitPaymentProcessor.CheckoutData, PaymentProcessor.CheckoutData> {
     @Override
     public PaymentProcessor.CheckoutData map(@NonNull final SplitPaymentProcessor.CheckoutData val) {
-        return new PaymentProcessor.CheckoutData(val.paymentDataList.get(0), val.checkoutPreference);
+        return new PaymentProcessor.CheckoutData(val.paymentDataList.get(0), val.checkoutPreference, val.securityType);
     }
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/core/internal/PaymentProcessorMapper.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/core/internal/PaymentProcessorMapper.java
@@ -42,7 +42,7 @@ public class PaymentProcessorMapper extends Mapper<PaymentProcessor, SplitPaymen
             }
 
             @Override
-            public boolean supportsSplitPayment(@NonNull final CheckoutPreference checkoutPreference) {
+            public boolean supportsSplitPayment(@Nullable final CheckoutPreference checkoutPreference) {
                 return false;
             }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/PaymentService.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/PaymentService.java
@@ -281,11 +281,12 @@ public class PaymentService implements PaymentRepository {
 
     private void pay() {
         final CheckoutPreference checkoutPreference = paymentSettingRepository.getCheckoutPreference();
+        final String securityType = paymentSettingRepository.getSecurityType().getValue();
         if (paymentProcessor.shouldShowFragmentOnPayment(checkoutPreference)) {
             handlerWrapper.onVisualPayment();
         } else {
             final SplitPaymentProcessor.CheckoutData checkoutData =
-                new SplitPaymentProcessor.CheckoutData(getPaymentDataList(), checkoutPreference);
+                new SplitPaymentProcessor.CheckoutData(getPaymentDataList(), checkoutPreference, securityType);
             paymentProcessor.startPayment(context, checkoutData, handlerWrapper);
         }
     }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/PaymentSettingService.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/PaymentSettingService.java
@@ -3,6 +3,7 @@ package com.mercadopago.android.px.internal.datasource;
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import com.mercadopago.android.px.addons.model.internal.SecurityType;
 import com.mercadopago.android.px.configuration.AdvancedConfiguration;
 import com.mercadopago.android.px.configuration.DiscountParamsConfiguration;
 import com.mercadopago.android.px.configuration.PaymentConfiguration;
@@ -28,6 +29,7 @@ public class PaymentSettingService implements PaymentSettingRepository {
     private static final String PREF_CURRENCY = "PREF_CURRENCY";
     private static final String PREF_PRIVATE_KEY = "PREF_PRIVATE_KEY";
     private static final String PREF_TOKEN = "PREF_TOKEN";
+    private static final String PREF_SECURITY_TYPE = "PREF_SECURITY_TYPE";
     private static final String PREF_PRODUCT_ID = "PREF_PRODUCT_ID";
     private static final String PREF_LABELS = "PREF_LABELS";
     private static final String PREF_AMOUNT_ROW_ENABLED = "PREF_AMOUNT_ROW_ENABLED";
@@ -64,6 +66,13 @@ public class PaymentSettingService implements PaymentSettingRepository {
     public void configure(@NonNull final Token token) {
         final SharedPreferences.Editor edit = sharedPreferences.edit();
         edit.putString(PREF_TOKEN, JsonUtil.toJson(token));
+        edit.apply();
+    }
+
+    @Override
+    public void configure(@NonNull final SecurityType secondFactor) {
+        final SharedPreferences.Editor edit = sharedPreferences.edit();
+        edit.putString(PREF_SECURITY_TYPE, secondFactor.name());
         edit.apply();
     }
 
@@ -201,6 +210,12 @@ public class PaymentSettingService implements PaymentSettingRepository {
     @Override
     public Token getToken() {
         return JsonUtil.fromJson(sharedPreferences.getString(PREF_TOKEN, ""), Token.class);
+    }
+
+    @NonNull
+    @Override
+    public SecurityType getSecurityType() {
+        return SecurityType.valueOf(sharedPreferences.getString(PREF_SECURITY_TYPE, SecurityType.NONE.name()));
     }
 
     @Override

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/di/Session.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/di/Session.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import com.mercadopago.android.px.addons.BehaviourProvider;
 import com.mercadopago.android.px.addons.ESCManagerBehaviour;
+import com.mercadopago.android.px.addons.model.internal.SecurityType;
 import com.mercadopago.android.px.addons.model.SecurityValidationData;
 import com.mercadopago.android.px.configuration.AdvancedConfiguration;
 import com.mercadopago.android.px.configuration.PaymentConfiguration;
@@ -469,8 +470,11 @@ public final class Session extends ApplicationModule implements AmountComponent 
             : checkout.getAdvancedConfiguration().getProductId();
         networkModule.getSessionIdProvider().configure(checkout.getTrackingConfiguration().getSessionId());
         MPTracker.getInstance().setSessionId(checkout.getTrackingConfiguration().getSessionId());
-        MPTracker.getInstance().setSecurityEnabled(BehaviourProvider.getSecurityBehaviour()
-            .isSecurityEnabled(new SecurityValidationData.Builder(productId).build()));
+        boolean securityEnabled = BehaviourProvider.getSecurityBehaviour()
+            .isSecurityEnabled(new SecurityValidationData.Builder(productId).build());
+        MPTracker.getInstance().setSecurityEnabled(securityEnabled);
         networkModule.getProductIdProvider().configure(productId);
+        getConfigurationModule().getPaymentSettings().configure(
+            securityEnabled ? SecurityType.SECOND_FACTOR : SecurityType.NONE);
     }
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/plugins/PaymentProcessorActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/plugins/PaymentProcessorActivity.java
@@ -127,9 +127,9 @@ public final class PaymentProcessorActivity extends PXActivity
             .getPaymentDataList();
 
         final CheckoutPreference checkoutPreference = paymentSettings.getCheckoutPreference();
-
+        final String securityType = paymentSettings.getSecurityType().getValue();
         final SplitPaymentProcessor.CheckoutData checkoutData =
-            new SplitPaymentProcessor.CheckoutData(paymentData, checkoutPreference);
+            new SplitPaymentProcessor.CheckoutData(paymentData, checkoutPreference, securityType);
 
         final Fragment fragment = paymentProcessor.getFragment(checkoutData, this);
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/repository/PaymentSettingRepository.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/repository/PaymentSettingRepository.java
@@ -2,6 +2,7 @@ package com.mercadopago.android.px.internal.repository;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import com.mercadopago.android.px.addons.model.internal.SecurityType;
 import com.mercadopago.android.px.configuration.AdvancedConfiguration;
 import com.mercadopago.android.px.configuration.PaymentConfiguration;
 import com.mercadopago.android.px.model.Currency;
@@ -28,13 +29,15 @@ public interface PaymentSettingRepository {
 
     void configure(@Nullable final PaymentConfiguration paymentConfiguration);
 
-    void configure(@NonNull Configuration configuration);
+    void configure(@NonNull final Configuration configuration);
 
-    void configure(@NonNull Token token);
+    void configure(@NonNull final Token token);
+
+    void configure(@NonNull final SecurityType secondFactor);
 
     void clearToken();
 
-    void configurePreferenceId(@Nullable String preferenceId);
+    void configurePreferenceId(@Nullable final String preferenceId);
 
     void configurePrivateKey(@Nullable final String privateKey);
 
@@ -73,6 +76,9 @@ public interface PaymentSettingRepository {
 
     @Nullable
     Token getToken();
+
+    @NonNull
+    SecurityType getSecurityType();
 
     boolean hasToken();
 }


### PR DESCRIPTION
Se nos requirió a PX enviar un flag al momento de pagar como indicativo de si se le pidió o no al usuario validación durante el pago. Agregamos en la firma de la procesadora un atributo nuevo con este flag (securityType), para que los integradores lo propaguen a sus backends y posteriormente a payments. El dato se debe enviar a payments de la siguiente manera:
header {X-Tracking-Id=[platform:v1-whitelabel,operatingSystem:ALL,type:N/A,**securty:2fa**]}
Es decir, lo que se agrega a la llamada es "**security:2fa**" en ese header. En el caso que el flag indique que no hubo seguridad debería viajar como "security:none".