### PR TITLE
[Fix] Duplicate view and crash in silver bullet fixed

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_result/remedies/view/RetryPaymentFragment.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_result/remedies/view/RetryPaymentFragment.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import android.widget.TextView
 import com.mercadopago.android.px.R
 import com.mercadopago.android.px.internal.di.MapperProvider
+import com.mercadopago.android.px.internal.experiments.BadgeVariant
 import com.mercadopago.android.px.internal.extensions.gone
 import com.mercadopago.android.px.internal.extensions.visible
 import com.mercadopago.android.px.internal.features.express.slider.PaymentMethodFragment
@@ -69,6 +70,7 @@ internal class RetryPaymentFragment : Fragment(), PaymentMethodFragment.Disabled
         val model = MapperProvider.getPaymentMethodDescriptorMapper().map(methodData)
         model.formatForRemedy()
         payerCost?.let { model.setCurrentPayerCost(it.payerCostIndex) }
+        paymentMethodDescriptor.configureExperiment(BadgeVariant().default)
         paymentMethodDescriptor.update(model)
     }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/PaymentMethodDescriptorView.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/PaymentMethodDescriptorView.java
@@ -54,7 +54,9 @@ public class PaymentMethodDescriptorView extends LinearLayout {
     }
 
     public void configureExperiment(Variant variant) {
-        ExperimentHelper.INSTANCE.applyExperimentViewBy(experimentContainer, variant);
+        if (experimentContainer.getChildCount() == 0) {
+            ExperimentHelper.INSTANCE.applyExperimentViewBy(experimentContainer, variant);
+        }
         rightText = experimentContainer.findViewById(R.id.right_text);
     }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/PaymentMethodHeaderView.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/PaymentMethodHeaderView.java
@@ -118,7 +118,9 @@ public class PaymentMethodHeaderView extends FrameLayout {
     }
 
     private void configurePulseExperiment(@NonNull final PulseVariant variant) {
-        ExperimentHelper.INSTANCE.applyExperimentViewBy(experimentContainer, variant);
+        if (experimentContainer.getChildCount() == 0) {
+            ExperimentHelper.INSTANCE.applyExperimentViewBy(experimentContainer, variant);
+        }
 
         pulse = experimentContainer.findViewById(R.id.pulse);
         if (pulse != null) {


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
Vistas duplicadas, crash en remedy de silver bullet.

## Descripción
Se duplican las vistas de los experimentos cuando vuelvo de remedies, se soluciona crash con silver bullet.

## Cómo probarlo
1er bug: Aparece un remedy, botón seleccionar otro medio de pago, retorno a onetap.
2do bug: Con remedy Silverbullet

## Screenshots
<!--- Para bug fixes: Incluir screenshots o videos del antes y después -->
<!--- Para nuevos features: Incluir screenshots o videos de la nueva UI -->

## Tipo de cambio (para el release manager)
- [X] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
