### PR TITLE
[Release] Display info parcelized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## VERSION 4.48.3
+_24_06_2020_
+* FIX - DisplayInfo within PaymentMethod was not parcelized
+
 ## VERSION 4.48.2
 _17_06_2020_
 * FIX - Crash silverbullet remedy

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx1g
 # Current lib version
-version_to_deploy=4.48.2
+version_to_deploy=4.48.3
 # Compile versions
 build_tools_version=28.0.3
 min_api_level=19

--- a/px-services/src/main/java/com/mercadopago/android/px/model/PaymentMethod.java
+++ b/px-services/src/main/java/com/mercadopago/android/px/model/PaymentMethod.java
@@ -213,7 +213,7 @@ public class PaymentMethod implements Parcelable, Serializable {
         String maxString = in.readString();
         maxAllowedAmount = maxString != null ? new BigDecimal(maxString) : null;
         processingModes = in.createTypedArray(ProcessingMode.CREATOR);
-        in.readParcelable(DisplayInfo.class.getClassLoader());
+        displayInfo = in.readParcelable(DisplayInfo.class.getClassLoader());
     }
 
     public static final Creator<PaymentMethod> CREATOR = new Creator<PaymentMethod>() {


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
Display info dentro de paymentMethod no se estaba parcelizando correctamente.

## Descripción
Se empieza a storear displayinfo.

## Cómo probarlo
<!--- Para bug fixes: Describir cómo reproducir el comportamiento que generaba el bug -->
<!--- Para nuevos features: Se debe agregar el caso de uso a la app de ejemplos, y aquí se debe describir qué función de la app de ejemplos probar -->

## Screenshots
<!--- Para bug fixes: Incluir screenshots o videos del antes y después -->
<!--- Para nuevos features: Incluir screenshots o videos de la nueva UI -->

## Tipo de cambio (para el release manager)
- [X] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
