### PR TITLE
[Fix] Bug fixed

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/slider/PaymentMethodFragment.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/slider/PaymentMethodFragment.java
@@ -147,10 +147,9 @@ public abstract class PaymentMethodFragment<T extends DrawableFragmentItem>
     private void setDescriptionForAccessibility(@NonNull final String description) {
         final View rootView = getView();
         final DynamicHeightViewPager parent;
-        if (rootView != null && rootView.getParent() instanceof DynamicHeightViewPager) {
-            if ((parent = (DynamicHeightViewPager) rootView.getParent()).hasAccessibilityFocus()) {
-                parent.announceForAccessibility(description);
-            }
+        if (rootView != null && rootView.getParent() instanceof DynamicHeightViewPager &&
+            (parent = (DynamicHeightViewPager) rootView.getParent()).hasAccessibilityFocus()) {
+            parent.announceForAccessibility(description);
         }
         if (handler != null) {
             handler.postDelayed(() -> card.setContentDescription(description), 800);

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/slider/PaymentMethodFragment.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/slider/PaymentMethodFragment.java
@@ -148,7 +148,7 @@ public abstract class PaymentMethodFragment<T extends DrawableFragmentItem>
         final View rootView = getView();
         final DynamicHeightViewPager parent;
         if (rootView != null && rootView.getParent() instanceof DynamicHeightViewPager) {
-            if ((parent = (DynamicHeightViewPager) rootView.getParent()) != null && parent.hasAccessibilityFocus()) {
+            if ((parent = (DynamicHeightViewPager) rootView.getParent()).hasAccessibilityFocus()) {
                 parent.announceForAccessibility(description);
             }
         }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/slider/PaymentMethodFragment.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/slider/PaymentMethodFragment.java
@@ -147,9 +147,10 @@ public abstract class PaymentMethodFragment<T extends DrawableFragmentItem>
     private void setDescriptionForAccessibility(@NonNull final String description) {
         final View rootView = getView();
         final DynamicHeightViewPager parent;
-        if (rootView != null && (parent = (DynamicHeightViewPager) rootView.getParent()) != null &&
-            parent.hasAccessibilityFocus()) {
-            parent.announceForAccessibility(description);
+        if (rootView != null && rootView.getParent() instanceof DynamicHeightViewPager) {
+            if ((parent = (DynamicHeightViewPager) rootView.getParent()) != null && parent.hasAccessibilityFocus()) {
+                parent.announceForAccessibility(description);
+            }
         }
         if (handler != null) {
             handler.postDelayed(() -> card.setContentDescription(description), 800);


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
Crash en remedies cuando esta habilitado talkback.

## Descripción
El error ocurre cuando estamos tratando de castear el parent de la vista a un DynamicHeightViewPager. Este parent no coincide cuando estamos en remedies.

## Cómo probarlo
<!--- Para bug fixes: Describir cómo reproducir el comportamiento que generaba el bug -->
<!--- Para nuevos features: Se debe agregar el caso de uso a la app de ejemplos, y aquí se debe describir qué función de la app de ejemplos probar -->

## Screenshots
<!--- Para bug fixes: Incluir screenshots o videos del antes y después -->
<!--- Para nuevos features: Incluir screenshots o videos de la nueva UI -->

## Tipo de cambio (para el release manager)
- [x] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
