### PR TITLE
[Fix] Payment configuration is not valid if null

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/PaymentSettingService.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/PaymentSettingService.java
@@ -264,8 +264,7 @@ public class PaymentSettingService implements PaymentSettingRepository {
     @Override
     public boolean isPaymentConfigurationValid() {
         try {
-            getPaymentConfiguration();
-            return true;
+            return getPaymentConfiguration() != null;
         } catch (final Exception e) {
             return false;
         }


### PR DESCRIPTION
- No se toma como válido un posible PaymentConfiguration null.

![](https://media.giphy.com/media/AvMJCeu1EMmhG/giphy.gif)