### PR TITLE
[Fix] PaymentCongratstrack fix

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_congrats/model/PaymentCongratsModel.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_congrats/model/PaymentCongratsModel.java
@@ -54,6 +54,7 @@ public class PaymentCongratsModel implements Parcelable {
 
     //Internal PX data
     @Nullable private final String autoReturn;
+    private final boolean isStandAloneCongrats;
 
     //Internal PX Tracking data
     @Nullable private final Long paymentId;
@@ -85,6 +86,7 @@ public class PaymentCongratsModel implements Parcelable {
         discountCouponsAmount = builder.discountCouponsAmount;
         pxPaymentCongratsTracking = builder.pxPaymentCongratsTracking;
         autoReturn = builder.autoReturn;
+        isStandAloneCongrats = builder.isStandAloneCongrats;
     }
 
     protected PaymentCongratsModel(final Parcel in) {
@@ -118,6 +120,7 @@ public class PaymentCongratsModel implements Parcelable {
         }
         pxPaymentCongratsTracking = in.readParcelable(PXPaymentCongratsTracking.class.getClassLoader());
         autoReturn = in.readString();
+        isStandAloneCongrats = (Boolean) in.readValue(Boolean.class.getClassLoader());
     }
 
     @Override
@@ -159,6 +162,7 @@ public class PaymentCongratsModel implements Parcelable {
         }
         dest.writeParcelable(pxPaymentCongratsTracking, flags);
         dest.writeString(autoReturn);
+        dest.writeValue(isStandAloneCongrats);
     }
 
     @NonNull
@@ -261,6 +265,10 @@ public class PaymentCongratsModel implements Parcelable {
         return autoReturn;
     }
 
+    public boolean getIsStandAloneCongrats() {
+        return isStandAloneCongrats;
+    }
+
     @Nullable
     public PaymentCongratsResponse getPaymentCongratsResponse() {
         return paymentCongratsResponse;
@@ -345,6 +353,7 @@ public class PaymentCongratsModel implements Parcelable {
 
         //Internal PX data
         /* default */ String autoReturn;
+        /* default */ boolean isStandAloneCongrats = true;
 
         //Internal PX Tracking data
         /* default */ Long paymentId;
@@ -664,6 +673,15 @@ public class PaymentCongratsModel implements Parcelable {
          */
         /* default */ Builder withAutoReturn(final String autoReturn) {
             this.autoReturn = autoReturn;
+            return this;
+        }
+
+        /**
+         * @param isStandAloneCongrats standalone flag used for track path definition
+         * @return builder with the added boolean
+         */
+        /* default */ Builder withIsStandAloneCongrats(final boolean isStandAloneCongrats) {
+            this.isStandAloneCongrats = isStandAloneCongrats;
             return this;
         }
     }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_congrats/model/PaymentCongratsModelMapper.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_congrats/model/PaymentCongratsModelMapper.java
@@ -58,7 +58,8 @@ public class PaymentCongratsModelMapper extends Mapper<BusinessPaymentModel, Pay
             .withPaymentData(businessPaymentModel.getPaymentResult().getPaymentData())
             .withIconId(businessPayment.getIcon())
             .withAutoReturn(paymentSettings.getCheckoutPreference().getAutoReturn())
-            .withCustomSorting(businessPaymentModel.getCongratsResponse().hasCustomOrder());
+            .withCustomSorting(businessPaymentModel.getCongratsResponse().hasCustomOrder())
+            .withIsStandAloneCongrats(false);
 
         if (!businessPaymentModel.getPaymentResult().getPaymentDataList().isEmpty()) {
             builder.withPaymentMethodInfo(

--- a/px-checkout/src/main/java/com/mercadopago/android/px/tracking/internal/views/ResultViewTrack.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/tracking/internal/views/ResultViewTrack.kt
@@ -18,6 +18,7 @@ class ResultViewTrack : TrackWrapper {
     private val paymentStatus: String
     private val remediesResponse: RemediesResponse
     private var isPaymentCongratsFlow: Boolean = false
+    private var isStandaloneCongrats: Boolean = false
 
     constructor(paymentModel: PaymentModel, screenConfiguration: PaymentResultScreenConfiguration,
                 paymentSetting: PaymentSettingRepository, isMP: Boolean) {
@@ -29,6 +30,7 @@ class ResultViewTrack : TrackWrapper {
 
     constructor(paymentModel: PaymentCongratsModel, isMP: Boolean) {
         isPaymentCongratsFlow = true
+        isStandaloneCongrats = paymentModel.isStandAloneCongrats
         resultViewTrackModel = ResultViewTrackModel(paymentModel, isMP)
         paymentStatus = paymentModel.trackingPaymentStatus
         this.remediesResponse = RemediesResponse.EMPTY
@@ -45,7 +47,7 @@ class ResultViewTrack : TrackWrapper {
     }
 
     private fun getViewPath() = String.format(Locale.US,
-        if (isPaymentCongratsFlow) STANDALONE_PATH else CHECKOUT_PATH, paymentStatus)
+        if (isStandaloneCongrats) STANDALONE_PATH else CHECKOUT_PATH, paymentStatus)
 
     private fun getMappedResult(payment: PaymentResult): String {
         return when {


### PR DESCRIPTION
Se arregla que si viene por una standaloneCongrats se trackee por /payment_congrats y si no se trackea por /px_checkout 

## Motivación y Contexto
<!--- ¿Por qué este cambio es requerido? ¿Qué problema resuelve? -->

## Descripción
<!--- Describir los cambios en detalle -->

## Cómo probarlo
<!--- Para bug fixes: Describir cómo reproducir el comportamiento que generaba el bug -->
<!--- Para nuevos features: Se debe agregar el caso de uso a la app de ejemplos, y aquí se debe describir qué función de la app de ejemplos probar -->

## Screenshots
<!--- Para bug fixes: Incluir screenshots o videos del antes y después -->
<!--- Para nuevos features: Incluir screenshots o videos de la nueva UI -->

## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
