### PR TITLE
Check implementation in onRestore method to execute onTapShow only wh…

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/CheckoutRepositoryImpl.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/CheckoutRepositoryImpl.java
@@ -152,11 +152,13 @@ public class CheckoutRepositoryImpl implements CheckoutRepository {
                     public void success(final CheckoutResponse checkoutResponse) {
                         postResponse.call(checkoutResponse);
                         callback.success(checkoutResponse);
+                        paymentSettingRepository.configureFlowError(false);
                     }
 
                     @Override
                     public void failure(final ApiException apiException) {
                         callback.failure(apiException);
+                        paymentSettingRepository.configureFlowError(true);
                     }
                 };
             }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/PaymentSettingService.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/datasource/PaymentSettingService.java
@@ -39,6 +39,7 @@ public class PaymentSettingService implements PaymentSettingRepository {
     private static final String PREF_ONE_TAP_ENABLED = "PREF_ONE_TAP_ENABLED";
     private static final String PREF_CUSTOM_STRINGS = "PREF_CUSTOM_STRINGS";
     private static final String PREF_CONFIGURATION = "PREF_CONFIGURATION";
+    private static final String PREF_FLOW_ERROR = "pref_flow_error";
     private static final String FILE_PAYMENT_CONFIG = "px_payment_config";
 
     @NonNull private final SharedPreferences sharedPreferences;
@@ -269,5 +270,17 @@ public class PaymentSettingService implements PaymentSettingRepository {
     @Override
     public String getPrivateKey() {
         return sharedPreferences.getString(PREF_PRIVATE_KEY, null);
+    }
+
+    @Override
+    public boolean getFlowError() {
+        return sharedPreferences.getBoolean(PREF_FLOW_ERROR, false);
+    }
+
+    @Override
+    public void configureFlowError(boolean error) {
+        final SharedPreferences.Editor edit = sharedPreferences.edit();
+        edit.putBoolean(PREF_FLOW_ERROR, error);
+        edit.apply();
     }
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutActivity.java
@@ -121,6 +121,13 @@ public class CheckoutActivity extends PXActivity<CheckoutPresenter>
         privateKey = savedInstanceState.getString(EXTRA_PRIVATE_KEY);
         merchantPublicKey = savedInstanceState.getString(EXTRA_PUBLIC_KEY);
         presenter.attachView(this);
+
+        if (presenter.paymentSettingRepository.getFlowError()) {
+            // TODO implementation track/log with error
+            // ....
+            return;
+        }
+
         presenter.onRestore();
     }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutPresenter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutPresenter.java
@@ -86,9 +86,7 @@ public class CheckoutPresenter extends BasePresenter<Checkout.View> implements C
 
     @Override
     public void onRestore() {
-        if (paymentSettingRepository.getCheckoutPreference() != null) {
-            showOneTap();
-        }
+        showOneTap();
     }
 
     @Override

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutPresenter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutPresenter.java
@@ -2,6 +2,7 @@ package com.mercadopago.android.px.internal.features.checkout;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import com.mercadolibre.android.cardform.internal.LifecycleListener;
 import com.mercadopago.android.px.internal.base.BasePresenter;
 import com.mercadopago.android.px.internal.experiments.KnownVariant;
@@ -25,19 +26,21 @@ public class CheckoutPresenter extends BasePresenter<Checkout.View> implements C
     @NonNull /* default */ final PaymentRepository paymentRepository;
     @NonNull /* default */ final PaymentSettingRepository paymentSettingRepository;
     @NonNull /* default */ final UserSelectionRepository userSelectionRepository;
-    @NonNull private final CheckoutRepository checkoutRepository;
-    @NonNull private final PostPaymentUrlsMapper postPaymentUrlsMapper;
+    @NonNull
+    private final CheckoutRepository checkoutRepository;
+    @NonNull
+    private final PostPaymentUrlsMapper postPaymentUrlsMapper;
     @NonNull /* default */ ExperimentsRepository experimentsRepository;
     private final boolean withPrefetch;
 
     /* default */ CheckoutPresenter(@NonNull final PaymentSettingRepository paymentSettingRepository,
-        @NonNull final UserSelectionRepository userSelectionRepository,
-        @NonNull final CheckoutRepository checkoutRepository,
-        @NonNull final PaymentRepository paymentRepository,
-        @NonNull final ExperimentsRepository experimentsRepository,
-        @NonNull final PostPaymentUrlsMapper postPaymentUrlsMapper,
-        @NonNull final MPTracker tracker,
-        final boolean withPrefetch) {
+                                    @NonNull final UserSelectionRepository userSelectionRepository,
+                                    @NonNull final CheckoutRepository checkoutRepository,
+                                    @NonNull final PaymentRepository paymentRepository,
+                                    @NonNull final ExperimentsRepository experimentsRepository,
+                                    @NonNull final PostPaymentUrlsMapper postPaymentUrlsMapper,
+                                    @NonNull final MPTracker tracker,
+                                    final boolean withPrefetch) {
         super(tracker);
         this.paymentSettingRepository = paymentSettingRepository;
         this.userSelectionRepository = userSelectionRepository;
@@ -63,7 +66,7 @@ public class CheckoutPresenter extends BasePresenter<Checkout.View> implements C
                     public void failure(final ApiException apiException) {
                         if (isViewAttached()) {
                             getView().showError(
-                                new MercadoPagoError(apiException, ApiUtil.RequestOrigin.POST_INIT));
+                                    new MercadoPagoError(apiException, ApiUtil.RequestOrigin.POST_INIT));
                         }
                     }
                 });
@@ -77,13 +80,15 @@ public class CheckoutPresenter extends BasePresenter<Checkout.View> implements C
         if (isViewAttached()) {
             getView().hideProgress();
             getView().showOneTap(ExperimentHelper.INSTANCE.getVariantFrom(
-                experimentsRepository.getExperiments(), KnownVariant.SCROLLED));
+                    experimentsRepository.getExperiments(), KnownVariant.SCROLLED));
         }
     }
 
     @Override
     public void onRestore() {
-        showOneTap();
+        if (paymentSettingRepository.getCheckoutPreference() != null) {
+            showOneTap();
+        }
     }
 
     @Override
@@ -98,32 +103,32 @@ public class CheckoutPresenter extends BasePresenter<Checkout.View> implements C
 
     @Override
     public void onPaymentResultResponse(@Nullable final Integer customResultCode, @Nullable final String backUrl,
-        @Nullable final String redirectUrl) {
+                                        @Nullable final String redirectUrl) {
         final IPaymentDescriptor payment = paymentRepository.getPayment();
         final PostPaymentUrlsMapper.Response postPaymentUrls = postPaymentUrlsMapper.map(
-            new PostPaymentUrlsMapper.Model(
-                redirectUrl, backUrl, payment, paymentSettingRepository.getCheckoutPreference(),
-                paymentSettingRepository.getSite().getId()
-            )
+                new PostPaymentUrlsMapper.Model(
+                        redirectUrl, backUrl, payment, paymentSettingRepository.getCheckoutPreference(),
+                        paymentSettingRepository.getSite().getId()
+                )
         );
         new PostCongratsDriver.Builder(payment, postPaymentUrls)
-            .customResponseCode(customResultCode)
-            .action(new PostCongratsDriver.Action() {
-                @Override
-                public void goToLink(@NonNull final String link) {
-                    getView().goToLink(link);
-                }
+                .customResponseCode(customResultCode)
+                .action(new PostCongratsDriver.Action() {
+                    @Override
+                    public void goToLink(@NonNull final String link) {
+                        getView().goToLink(link);
+                    }
 
-                @Override
-                public void openInWebView(@NonNull final String link) {
-                    getView().openInWebView(link);
-                }
+                    @Override
+                    public void openInWebView(@NonNull final String link) {
+                        getView().openInWebView(link);
+                    }
 
-                @Override
-                public void exitWith(@Nullable final Integer customResponseCode, @Nullable final Payment payment) {
-                    getView().finishWithPaymentResult(customResultCode, payment);
-                }
-            }).build().execute();
+                    @Override
+                    public void exitWith(@Nullable final Integer customResponseCode, @Nullable final Payment payment) {
+                        getView().finishWithPaymentResult(customResultCode, payment);
+                    }
+                }).build().execute();
     }
 
     @Override

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/repository/PaymentSettingRepository.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/repository/PaymentSettingRepository.kt
@@ -23,6 +23,7 @@ internal interface PaymentSettingRepository : ConfigurationProvider {
     val token: Token?
     val securityType: SecurityType
     val chargeRules: List<PaymentTypeChargeRule>
+    val flowError: Boolean
     fun hasToken(): Boolean
     fun configure(advancedConfiguration: AdvancedConfiguration)
     fun configure(publicKey: String)
@@ -35,6 +36,7 @@ internal interface PaymentSettingRepository : ConfigurationProvider {
     fun configure(secondFactor: SecurityType)
     fun configurePreferenceId(preferenceId: String?)
     fun configurePrivateKey(privateKey: String?)
+    fun configureFlowError(error: Boolean)
     fun clearToken()
     fun reset()
 }


### PR DESCRIPTION
…en pref is not null

<!--- Escribir un resumen de los cambios en el Título de arriba -->
A check has been implemented in onRestore to call onTapShow only when the pref is different from null.

## Motivación y Contexto
<!--- ¿Por qué este cambio es requerido? ¿Qué problema resuelve? -->
It occurs when we don't have the data a first time and we are coming from the error screen, when we fall into the onRestore method, onTapShow is called without all the necessary data to build the screen, and with the implemented verification method onTapShow will be called only and I have the "pref" filled in, which prevents the crash.

## Descripción
<!--- Describir los cambios en detalle -->

## Cómo probarlo
<!--- Para bug fixes: Describir cómo reproducir el comportamiento que generaba el bug -->
To simulate the error it is necessary to leave the device in airplane mode, and perform the first call "Custom initialize". After loading the error screen, exit from airplane mode and click "try again".

## Screenshots
<!--- Para bug fixes: Incluir screenshots o videos del antes y después -->
Before correction
![before_correction](https://user-images.githubusercontent.com/84389392/124813301-18f97c00-df3b-11eb-84be-a5a843337b77.gif)

<img width="1196" alt="Captura de Tela 2021-07-07 às 15 52 17" src="https://user-images.githubusercontent.com/84389392/124813492-51995580-df3b-11eb-9b36-78c2ed42f104.png">

After correction
![after_correction](https://user-images.githubusercontent.com/84389392/124812958-aab4b980-df3a-11eb-9de5-bab7a12762c0.gif)

## Tipo de cambio (para el release manager)
- [x] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

