### PR TITLE
[Fix] Saves checkout presenter screen state

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/Checkout.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/Checkout.java
@@ -1,5 +1,6 @@
 package com.mercadopago.android.px.internal.features.checkout;
 
+import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.mercadolibre.android.cardform.internal.LifecycleListener;
@@ -40,6 +41,8 @@ import com.mercadopago.android.px.model.exceptions.MercadoPagoError;
 
         void onCardAdded(@NonNull final String cardId, @NonNull final LifecycleListener.Callback callback);
 
-        void onRestore();
+        void onRestore(@NonNull final Bundle bundle);
+
+        void storeInBundle(@NonNull final Bundle bundle);
     }
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutActivity.java
@@ -101,6 +101,7 @@ public class CheckoutActivity extends PXActivity<CheckoutPresenter>
         super.onSaveInstanceState(outState);
         outState.putString(EXTRA_PRIVATE_KEY, privateKey);
         outState.putString(EXTRA_PUBLIC_KEY, merchantPublicKey);
+        presenter.storeInBundle(outState);
     }
 
     @Override
@@ -121,7 +122,7 @@ public class CheckoutActivity extends PXActivity<CheckoutPresenter>
         privateKey = savedInstanceState.getString(EXTRA_PRIVATE_KEY);
         merchantPublicKey = savedInstanceState.getString(EXTRA_PUBLIC_KEY);
         presenter.attachView(this);
-        presenter.onRestore();
+        presenter.onRestore(savedInstanceState);
     }
 
     @Override

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutPresenter.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutPresenter.java
@@ -1,12 +1,13 @@
 package com.mercadopago.android.px.internal.features.checkout;
 
+import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.mercadolibre.android.cardform.internal.LifecycleListener;
 import com.mercadopago.android.px.internal.base.BasePresenter;
 import com.mercadopago.android.px.internal.experiments.KnownVariant;
-import com.mercadopago.android.px.internal.repository.ExperimentsRepository;
 import com.mercadopago.android.px.internal.repository.CheckoutRepository;
+import com.mercadopago.android.px.internal.repository.ExperimentsRepository;
 import com.mercadopago.android.px.internal.repository.PaymentRepository;
 import com.mercadopago.android.px.internal.repository.PaymentSettingRepository;
 import com.mercadopago.android.px.internal.repository.UserSelectionRepository;
@@ -22,6 +23,8 @@ import com.mercadopago.android.px.tracking.internal.MPTracker;
 
 public class CheckoutPresenter extends BasePresenter<Checkout.View> implements Checkout.Actions {
 
+    private static final String EXTRA_SHOWING_ONE_TAP = "showing_one_tap";
+
     @NonNull /* default */ final PaymentRepository paymentRepository;
     @NonNull /* default */ final PaymentSettingRepository paymentSettingRepository;
     @NonNull /* default */ final UserSelectionRepository userSelectionRepository;
@@ -29,6 +32,7 @@ public class CheckoutPresenter extends BasePresenter<Checkout.View> implements C
     @NonNull private final PostPaymentUrlsMapper postPaymentUrlsMapper;
     @NonNull /* default */ ExperimentsRepository experimentsRepository;
     private final boolean withPrefetch;
+    /* default */ boolean showingOneTap = false;
 
     /* default */ CheckoutPresenter(@NonNull final PaymentSettingRepository paymentSettingRepository,
         @NonNull final UserSelectionRepository userSelectionRepository,
@@ -75,6 +79,7 @@ public class CheckoutPresenter extends BasePresenter<Checkout.View> implements C
 
     /* default */ void showOneTap() {
         if (isViewAttached()) {
+            showingOneTap = true;
             getView().hideProgress();
             getView().showOneTap(ExperimentHelper.INSTANCE.getVariantFrom(
                 experimentsRepository.getExperiments(), KnownVariant.SCROLLED));
@@ -82,8 +87,16 @@ public class CheckoutPresenter extends BasePresenter<Checkout.View> implements C
     }
 
     @Override
-    public void onRestore() {
-        showOneTap();
+    public void onRestore(@NonNull final Bundle bundle) {
+        showingOneTap = bundle.getBoolean(EXTRA_SHOWING_ONE_TAP);
+        if (showingOneTap) {
+            showOneTap();
+        }
+    }
+
+    @Override
+    public void storeInBundle(@NonNull final Bundle bundle) {
+        bundle.putBoolean(EXTRA_SHOWING_ONE_TAP, showingOneTap);
     }
 
     @Override


### PR DESCRIPTION
This fixes the crash showing one tap after on restore when there was an error.