### PR TITLE
[Fix] Wrong transition onBackPressed

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutActivity.java
@@ -150,6 +150,7 @@ public class CheckoutActivity extends PXActivity<CheckoutPresenter>
             }
 
             super.onBackPressed();
+            overrideTransitionOut();
         }
     }
 


### PR DESCRIPTION
## Motivación y Contexto

Al hacer back en el checkout se ejecutaba la animacion de "continuar", es decir, la pantalla del checkout se deslizaba hacia la izquierda, y la pantalla anterior, aparecia desde la derecha. 

## Descripción

El fix consiste en llamar al metodo que ya existia para hacerle override a esta transicion y que al hacer back, la animacion sea de "salida"

## Cómo probarlo


## Screenshots
<!--- Para bug fixes: Incluir screenshots o videos del antes y después -->
<!--- Para nuevos features: Incluir screenshots o videos de la nueva UI -->

## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->
