### PR TITLE
[enhancement] Add status to validation programs

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/validation_program/ValidationProgramUseCase.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/validation_program/ValidationProgramUseCase.kt
@@ -19,7 +19,9 @@ internal class ValidationProgramUseCase @JvmOverloads constructor(
     override suspend fun doExecute(param: List<PaymentData>?): Response<String?, MercadoPagoError> {
         val mainPaymentData = param?.firstOrNull() ?: throw IllegalStateException("No payment data available")
         val payerPaymentMethodId = mainPaymentData.token?.cardId ?: mainPaymentData.paymentMethod.id
-        val validationProgram = applicationSelectionRepository[payerPaymentMethodId].validationPrograms?.firstOrNull()
+        val validationProgram = applicationSelectionRepository[payerPaymentMethodId].validationPrograms?.firstOrNull {
+            validationProgram -> validationProgram.status.enabled
+        }
         val knownValidationProgram = KnownValidationProgram[validationProgram?.id]
         when (knownValidationProgram) {
             KnownValidationProgram.STP -> authenticateUseCase.execute(mainPaymentData)

--- a/px-services/src/main/java/com/mercadopago/android/px/model/internal/Application.kt
+++ b/px-services/src/main/java/com/mercadopago/android/px/model/internal/Application.kt
@@ -15,8 +15,11 @@ data class Application(
 
     data class ValidationProgram(
         val id: String,
-        val mandatory: Boolean
-    )
+        val mandatory: Boolean,
+        val status: Status) {
+
+        data class Status(val enabled: Boolean, val reason: String)
+    }
 
     enum class KnownValidationProgram(val value: String) {
         STP("stp"),


### PR DESCRIPTION
Firma acordada con backend:

`"status": {
      "enabled": "false",
      "reason": ""
    }`

Debemos aplicar el primer validation program que venga habilitado.