### PR TITLE
[PXN-2186] - Fix Resource Not Found Exception

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/slider/PaymentMethodFragment.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/slider/PaymentMethodFragment.java
@@ -300,6 +300,8 @@ public abstract class PaymentMethodFragment<T extends DrawableFragmentItem>
         final GenericDialogItem genericDialogItem = model.getGenericDialogItem();
         if (genericDialogItem != null) {
             card.setOnClickListener(v -> GenericDialog.showDialog(getChildFragmentManager(), genericDialogItem));
+        } else {
+            card.setOnClickListener(null);
         }
     }
 


### PR DESCRIPTION
The  app crashes after the flow of displaying a dialog from a disabled card and when clicking again when enabled.

## Motivación y Contexto
This fix prevents the application from crashing after clicking an enabled card after viewing the dialog box with a payment option disabled.

## Descripción
Added a if statement in the enable() method in the PaymentMethodFragment class to remove and clear the setOnClickListener if it didn't pass the if. Without this treatment, the reference of the listener in the disable() method causes the crash.

## Cómo probarlo
Mock for test: https://run.mocky.io/v3/fe1eb0a6-8f57-43c6-a124-82e7f36bf5eb
- Select a credit card and change to débit payment. 
- Click on the card to show dialog explain which is not possible occurs payment with this option. 
- Change to credit payment
- Click again in the card and the crash will appear. 


## Screenshots
<b>Crash: </b> 
![error](https://user-images.githubusercontent.com/86365750/128020025-d9a1926e-4823-4372-8b94-65d3ccf7d520.gif)
<b>Fix: </b>
![fix](https://user-images.githubusercontent.com/86365750/128020091-520b662c-1d28-4298-a07f-f33cff9c6ea7.gif)


## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
