### PR TITLE
[Update] PxBehaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## VERSION 5.0.0
+* FEATURE - Migration of Nudata flow to Dynamic Features also update PXBehaviourConfigurer to avoid null sets.
+
+
 ## VERSION 4.85.0
 _28_07_2021_
 * FEATURE - Adds Accept third party card flag.

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # Current lib version
-libraryVersion=4.85.0
+libraryVersion=5.0.0
 # Compile versions
 buildTools=29.0.2
 minApiLevel=19

--- a/px-addons/src/main/java/com/mercadopago/android/px/addons/PXBehaviourConfigurer.java
+++ b/px-addons/src/main/java/com/mercadopago/android/px/addons/PXBehaviourConfigurer.java
@@ -47,13 +47,33 @@ public final class PXBehaviourConfigurer {
         return this;
     }
 
+    /**
+     * Apply only an nonnull configuration to override previous configuration
+     * with nonnull values.
+     * This configs may be null at start flow but BehaviourProvider retrieves a new one
+     * with basic behaviour.
+     */
     public void configure() {
-        BehaviourProvider.set(securityBehaviour);
-        BehaviourProvider.set(escManagerBehaviour);
-        BehaviourProvider.set(trackingBehaviour);
-        BehaviourProvider.set(localeBehaviour);
-        BehaviourProvider.set(flowBehaviour);
-        BehaviourProvider.set(threeDSBehaviour);
-        BehaviourProvider.set(tokenDeviceBehaviour);
+        if (securityBehaviour != null) {
+            BehaviourProvider.set(securityBehaviour);
+        }
+        if (escManagerBehaviour != null) {
+            BehaviourProvider.set(escManagerBehaviour);
+        }
+        if (trackingBehaviour != null) {
+            BehaviourProvider.set(trackingBehaviour);
+        }
+        if (localeBehaviour != null) {
+            BehaviourProvider.set(localeBehaviour);
+        }
+        if (flowBehaviour != null) {
+            BehaviourProvider.set(flowBehaviour);
+        }
+        if (threeDSBehaviour != null) {
+            BehaviourProvider.set(threeDSBehaviour);
+        }
+        if (tokenDeviceBehaviour != null) {
+            BehaviourProvider.set(tokenDeviceBehaviour);
+        }
     }
 }


### PR DESCRIPTION
## Descripción
Agregamos soporte para que las instancias que llegan al Behaviour , si son null, no se seteen, para mantener las instancias estaticas que se hayan seteado previamente.
Si eran null, continuarán así, sino se mantiene el último seteo, ya que en caso de ser null devuelven una instancia new con valores por default, no hace sentido permitir el seteo de null.

## Motivación y Contexto
Porque migramos a df la lógica de nudata

## Cómo probarlo
https://docs.google.com/spreadsheets/d/1h9vVHleTrNXd7djlm8spd43r8MJAupr5QJUGuRXbDsk/edit#gid=1911876799 dejamos ese doc donde junto con PX armaremos las pruebas y la wiki de df donde menciona como probar los flujos dinamicos: 
https://sites.google.com/mercadolibre.com/mobile/arquitectura/android/app-bundle/c%C3%B3mo-pruebo-mi-modulo-dinamico/internal-app-sharing?authuser=0

## Screenshots
N/A

## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [X] Mi cambio afecta a los integradores internos
Sólo se agrega un check

## Compartir conocimiento
Sólamente agregamos un check al patron builder que ya tienen.