### PR TITLE
Implementation of third-party card message on congrats screen

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/business_result/CongratsViewModel.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/business_result/CongratsViewModel.kt
@@ -14,5 +14,6 @@ internal data class CongratsViewModel(
     val actionCardViewData: MLBusinessActionCardViewData?,
     val crossSellingBoxData: List<MLBusinessCrossSellingBoxData>?,
     val viewReceipt: PaymentCongratsResponse.Action?,
-    val customOrder: Boolean
+    val customOrder: Boolean,
+    val operationInfo: PaymentCongratsResponse.OperationInfo?
 )

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/business_result/PaymentCongratsResponseMapper.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/business_result/PaymentCongratsResponseMapper.java
@@ -2,6 +2,8 @@ package com.mercadopago.android.px.internal.features.business_result;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import com.mercadolibre.android.andesui.message.hierarchy.AndesMessageHierarchy;
+import com.mercadolibre.android.andesui.message.type.AndesMessageType;
 import com.mercadopago.android.px.internal.features.payment_congrats.model.PaymentCongratsResponse;
 import com.mercadopago.android.px.internal.features.payment_congrats.model.PaymentCongratsText;
 import com.mercadopago.android.px.internal.mappers.Mapper;
@@ -21,7 +23,8 @@ public class PaymentCongratsResponseMapper extends Mapper<CongratsResponse, Paym
             congratsResponse.getCustomOrder(),
             congratsResponse.getBackUrl(),
             congratsResponse.getRedirectUrl(),
-            getAutoReturn(congratsResponse.getAutoReturn()));
+            getAutoReturn(congratsResponse.getAutoReturn()),
+            getOperationInfo(congratsResponse.getOperationInfo()));
     }
 
     private PaymentCongratsResponse.Loyalty getLoyalty(final CongratsResponse.Score score) {
@@ -111,6 +114,16 @@ public class PaymentCongratsResponseMapper extends Mapper<CongratsResponse, Paym
     private PaymentCongratsResponse.AutoReturn getAutoReturn(@Nullable final CongratsResponse.AutoReturn autoReturn) {
         if (autoReturn != null) {
             return new PaymentCongratsResponse.AutoReturn(autoReturn.getLabel(), autoReturn.getSeconds());
+        }
+        return null;
+    }
+
+    @Nullable
+    private PaymentCongratsResponse.OperationInfo getOperationInfo(@Nullable final CongratsResponse.OperationInfo operationInfo) {
+        if (operationInfo != null) {
+            return
+                new PaymentCongratsResponse.OperationInfo(AndesMessageHierarchy.valueOf(operationInfo.getHierarchy().toUpperCase()),
+                AndesMessageType.valueOf(operationInfo.getType().toUpperCase()), operationInfo.getBody());
         }
         return null;
     }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentFragment.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/express/ExpressPaymentFragment.java
@@ -395,6 +395,7 @@ public class ExpressPaymentFragment extends BaseFragment implements ExpressPayme
 
     @Override
     public void onSaveInstanceState(@NonNull final Bundle outState) {
+
         outState.putSerializable(EXTRA_RENDER_MODE, renderMode);
         outState.putSerializable(EXTRA_NAVIGATION_STATE, navigationState);
         if (presenter != null) {

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_congrats/model/CongratsViewModelMapper.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_congrats/model/CongratsViewModelMapper.java
@@ -50,7 +50,8 @@ public class CongratsViewModelMapper extends Mapper<PaymentCongratsResponse, Con
             getDownloadAppData(discount),
             getExpenseSplitData(paymentCongratsResponse.getExpenseSplit()),
             getCrossSellingBoxData(paymentCongratsResponse.getCrossSellings()),
-            paymentCongratsResponse.getViewReceipt(), paymentCongratsResponse.hasCustomOrder());
+            paymentCongratsResponse.getViewReceipt(), paymentCongratsResponse.hasCustomOrder(),
+            getOperationInfo(paymentCongratsResponse.getOperationInfo()));
     }
 
     @Nullable
@@ -317,5 +318,13 @@ public class CongratsViewModelMapper extends Mapper<PaymentCongratsResponse, Con
     @Nullable
     private MLBusinessActionCardViewData getExpenseSplitData(@Nullable final PaymentCongratsResponse.ExpenseSplit moneySplit) {
         return MLBusinessMapper.map(moneySplit);
+    }
+
+    @Nullable
+    private PaymentCongratsResponse.OperationInfo getOperationInfo(@Nullable final PaymentCongratsResponse.OperationInfo operationInfo) {
+        if (operationInfo != null) {
+            return operationInfo;
+        }
+        return null;
     }
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_congrats/model/PaymentCongratsModel.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_congrats/model/PaymentCongratsModel.java
@@ -355,6 +355,8 @@ public class PaymentCongratsModel implements Parcelable {
         /* default */ PaymentData paymentData;
         /* default */ BigDecimal discountCouponsAmount;
 
+        //
+        PaymentCongratsResponse.OperationInfo operationInfo;
 
         public Builder() {
         }
@@ -376,7 +378,7 @@ public class PaymentCongratsModel implements Parcelable {
             }
             paymentCongratsResponse =
                 new PaymentCongratsResponse(loyalty, discount, expenseSplit, crossSelling, receiptAction,
-                    customSorting, backUrl, redirectUrl, autoReturn);
+                    customSorting, backUrl, redirectUrl, autoReturn, operationInfo);
 
             return new PaymentCongratsModel(this);
         }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_congrats/model/PaymentCongratsResponse.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_congrats/model/PaymentCongratsResponse.kt
@@ -1,6 +1,9 @@
 package com.mercadopago.android.px.internal.features.payment_congrats.model
 
 import android.os.Parcelable
+import com.mercadolibre.android.andesui.message.AndesMessage
+import com.mercadolibre.android.andesui.message.hierarchy.AndesMessageHierarchy
+import com.mercadolibre.android.andesui.message.type.AndesMessageType
 import kotlinx.android.parcel.Parcelize
 import kotlinx.android.parcel.RawValue
 
@@ -14,7 +17,8 @@ data class PaymentCongratsResponse(
     private val customOrder: Boolean = false,
     val backUrl: String? = null,
     val redirectUrl: String? = null,
-    val autoReturn: AutoReturn? = null): Parcelable {
+    val autoReturn: AutoReturn? = null,
+    val operationInfo: OperationInfo? = null): Parcelable {
 
     fun getCrossSellings() = crossSellings ?: emptyList()
     fun hasCustomOrder() = customOrder
@@ -102,6 +106,13 @@ data class PaymentCongratsResponse(
     data class AutoReturn(
         val label: String? = null,
         val seconds: Int? = null
+    ) : Parcelable
+
+    @Parcelize
+    data class OperationInfo(
+        val hierarchy: AndesMessageHierarchy,
+        val type: AndesMessageType,
+        val body: String
     ) : Parcelable
 
     companion object {

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_result/PaymentResultActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_result/PaymentResultActivity.java
@@ -45,6 +45,7 @@ import com.mercadopago.android.px.internal.viewmodel.ChangePaymentMethodPostPaym
 import com.mercadopago.android.px.internal.viewmodel.PaymentModel;
 import com.mercadopago.android.px.internal.viewmodel.PostPaymentAction;
 import com.mercadopago.android.px.internal.viewmodel.RecoverPaymentPostPaymentAction;
+import com.mercadopago.android.px.model.OperationInfo;
 import com.mercadopago.android.px.model.exceptions.ApiException;
 import com.mercadopago.android.px.model.exceptions.MercadoPagoError;
 import kotlin.Unit;

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_result/viewmodel/PaymentResultViewModel.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_result/viewmodel/PaymentResultViewModel.kt
@@ -6,6 +6,7 @@ import com.mercadopago.android.px.internal.features.payment_result.remedies.Reme
 import com.mercadopago.android.px.internal.features.payment_result.presentation.PaymentResultFooter
 import com.mercadopago.android.px.internal.view.PaymentResultBody
 import com.mercadopago.android.px.internal.view.PaymentResultHeader
+import com.mercadopago.android.px.model.OperationInfo
 
 internal class PaymentResultViewModel(
     val headerModel: PaymentResultHeader.Model,
@@ -14,5 +15,6 @@ internal class PaymentResultViewModel(
     val bodyModel: PaymentResultBody.Model,
     val legacyViewModel: PaymentResultLegacyViewModel,
     val instructionModel: Instruction.Model?,
-    val autoReturnModel: CongratsAutoReturn.Model? = null
+    val autoReturnModel: CongratsAutoReturn.Model? = null,
+    val operationInfo: OperationInfo? = null
 )

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/PaymentResultBody.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/view/PaymentResultBody.java
@@ -10,6 +10,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import com.mercadolibre.android.andesui.message.AndesMessage;
 import com.mercadolibre.android.mlbusinesscomponents.components.actioncard.MLBusinessActionCardView;
 import com.mercadolibre.android.mlbusinesscomponents.components.actioncard.MLBusinessActionCardViewData;
 import com.mercadolibre.android.mlbusinesscomponents.components.common.dividingline.MLBusinessDividingLineView;
@@ -88,11 +89,24 @@ public final class PaymentResultBody extends LinearLayout {
         renderMoneySplit(model.congratsViewModel.getActionCardViewData(), listener);
         renderCrossSellingBox(model.congratsViewModel.getCrossSellingBoxData(), listener);
         renderReceipt(model.receiptId);
+        renderOperationInfo(model.congratsViewModel.getOperationInfo(), listener);
         renderHelp(model.help);
         renderFragment(R.id.px_fragment_container_top, model.topFragment);
         renderMethods(model);
         renderViewReceipt(model.congratsViewModel.getViewReceipt(), listener);
         renderFragment(R.id.px_fragment_container_bottom, model.bottomFragment);
+    }
+
+    private void renderOperationInfo(final PaymentCongratsResponse.OperationInfo operationInfo, final Listener listener) {
+        final AndesMessage operationInfoView = findViewById(R.id.operationInfo);
+        if (operationInfo != null) {
+            operationInfoView.setVisibility(VISIBLE);
+            operationInfoView.setBody(operationInfo.getBody());
+            operationInfoView.setHierarchy(operationInfo.getHierarchy());
+            operationInfoView.setType(operationInfo.getType());
+        } else {
+            operationInfoView.setVisibility(GONE);
+        }
     }
 
     private void renderLoyalty(@Nullable final MLBusinessLoyaltyRingData loyaltyData,

--- a/px-checkout/src/main/res/layout/px_payment_result_body.xml
+++ b/px-checkout/src/main/res/layout/px_payment_result_body.xml
@@ -29,6 +29,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
 
+    <com.mercadolibre.android.andesui.message.AndesMessage
+        android:id="@+id/operationInfo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/andes_thumbnail_size_32"
+        android:layout_marginRight="@dimen/andes_thumbnail_size_32" />
+
     <com.mercadopago.android.px.internal.view.PaymentResultMethod
         android:id="@+id/primaryMethod"
         android:layout_width="match_parent"

--- a/px-checkout/src/main/res/layout/px_payment_result_body_custom_order.xml
+++ b/px-checkout/src/main/res/layout/px_payment_result_body_custom_order.xml
@@ -28,6 +28,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
 
+    <com.mercadolibre.android.andesui.message.AndesMessage
+        android:id="@+id/operationInfo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/andes_thumbnail_size_32"
+        android:layout_marginRight="@dimen/andes_thumbnail_size_32" />
+
     <FrameLayout
         android:id="@+id/px_fragment_container_top"
         android:layout_width="match_parent"

--- a/px-checkout/src/test/java/com/mercadopago/android/px/internal/view/PaymentResultBodyTest.kt
+++ b/px-checkout/src/test/java/com/mercadopago/android/px/internal/view/PaymentResultBodyTest.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
+import com.facebook.drawee.backends.pipeline.Fresco
 import com.mercadolibre.android.mlbusinesscomponents.common.MLBusinessSingleItem
 import com.mercadolibre.android.mlbusinesscomponents.components.actioncard.MLBusinessActionCardViewData
 import com.mercadolibre.android.mlbusinesscomponents.components.common.downloadapp.MLBusinessDownloadAppData
@@ -48,6 +49,10 @@ class PaymentResultBodyTest : BasicRobolectricTest() {
         `when`(packageManager.getApplicationInfo(anyString(), anyInt())).thenReturn(mercadoPagoAppInfo)
         `when`(context.packageManager).thenReturn(packageManager)
 
+        if (!Fresco.hasBeenInitialized()) {
+            Fresco.initialize(context)
+        }
+
         body = PaymentResultBody(context)
         modelBuilder = PaymentResultBody.Model.Builder().setCongratsViewModel(congratsViewModel)
     }
@@ -70,6 +75,7 @@ class PaymentResultBodyTest : BasicRobolectricTest() {
             assertGone(R.id.px_fragment_container_important)
             assertGone(R.id.px_fragment_container_top)
             assertGone(R.id.px_fragment_container_bottom)
+            assertGone(R.id.operationInfo)
         }
     }
 

--- a/px-services/src/main/java/com/mercadopago/android/px/internal/core/LanguageInterceptor.kt
+++ b/px-services/src/main/java/com/mercadopago/android/px/internal/core/LanguageInterceptor.kt
@@ -1,5 +1,7 @@
 package com.mercadopago.android.px.internal.core
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.mercadopago.android.px.addons.LocaleBehaviour
 import okhttp3.Interceptor
 import okhttp3.Response
@@ -7,6 +9,7 @@ import java.io.IOException
 
 internal class LanguageInterceptor(private val localeBehaviour: LocaleBehaviour) : Interceptor {
 
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()

--- a/px-services/src/main/java/com/mercadopago/android/px/model/OperationInfo.kt
+++ b/px-services/src/main/java/com/mercadopago/android/px/model/OperationInfo.kt
@@ -1,0 +1,11 @@
+package com.mercadopago.android.px.model
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+data class OperationInfo(
+    val hierarchy: String,
+    val type: String,
+    val body: String
+) : Parcelable

--- a/px-services/src/main/java/com/mercadopago/android/px/model/internal/CongratsResponse.kt
+++ b/px-services/src/main/java/com/mercadopago/android/px/model/internal/CongratsResponse.kt
@@ -20,7 +20,8 @@ data class CongratsResponse(
     val backUrl: String? = null,
     val primaryButton: Button? = null,
     val secondaryButton: Button? = null,
-    val instructions: Instruction? = null
+    val instructions: Instruction? = null,
+    val operationInfo: OperationInfo? = null
 ) : Parcelable {
 
     fun getCrossSellings() = crossSellingList ?: emptyList()
@@ -105,6 +106,13 @@ data class CongratsResponse(
     data class AutoReturn(
         val label: String,
         val seconds: Int
+    ) : Parcelable
+
+    @Parcelize
+    data class OperationInfo(
+        val hierarchy: String,
+        val type: String,
+        val body: String
     ) : Parcelable
 
     companion object {

--- a/px-services/src/main/java/com/mercadopago/android/px/services/MercadoPagoServices.java
+++ b/px-services/src/main/java/com/mercadopago/android/px/services/MercadoPagoServices.java
@@ -1,8 +1,10 @@
 package com.mercadopago.android.px.services;
 
 import android.content.Context;
+import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import com.mercadopago.android.px.addons.BehaviourProvider;
 import com.mercadopago.android.px.internal.model.SecurityType;
 import com.mercadopago.android.px.internal.services.BankDealService;
@@ -141,6 +143,7 @@ public class MercadoPagoServices {
         service.updateToken(tokenId, publicKey, privateKey, securityCodeIntent).enqueue(callback);
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     public void getBankDeals(final Callback<List<BankDeal>> callback) {
         final BankDealService service = retrofitClient.create(BankDealService.class);
         service.getBankDeals(publicKey, privateKey, BehaviourProvider.getLocaleBehaviour().getLocale().toLanguageTag())
@@ -165,6 +168,7 @@ public class MercadoPagoServices {
         service.getIdentificationTypesForAuthUser(accessToken).enqueue(callback);
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     public void getInstallments(final String bin,
         final BigDecimal amount,
         final Long issuerId,


### PR DESCRIPTION
The operation_info property was implemented in the congrats api's return

## Motivación y Contexto
This implementation was made only for users in Argentina so when a customer adds a third party card, he will receive a message to be aware that the third party card will not be saved. (BCRA regulation)

## Descripción
A new class was created to receive the operation_info node with the information regarding the message, this node will only be returned when it is a third-party card.

Also included in the "px_payment_result_body.xml" and "px_payment_result_body_custom_order.xml" layouts the "AndesMessage" component

## Cómo probarlo
For the test it is only necessary to use an Argentine user and make a payment with a third party card.

## Screenshots
![Screenshot_1629482287](https://user-images.githubusercontent.com/84389392/130274753-ba1f6dc8-3079-4dc3-b64d-3056168878dd.png)

## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
