### PR TITLE
[PXN-2265] Fix - TyC de credits MLM

### DIFF
--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/TermsAndConditionsActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/TermsAndConditionsActivity.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.util.Base64;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.URLUtil;
@@ -17,6 +18,7 @@ import com.mercadopago.android.px.R;
 import com.mercadopago.android.px.internal.base.PXActivity;
 import com.mercadopago.android.px.internal.di.Session;
 import com.mercadopago.android.px.tracking.internal.views.TermsAndConditionsViewTracker;
+import java.nio.charset.StandardCharsets;
 
 public class TermsAndConditionsActivity extends PXActivity {
 
@@ -70,19 +72,21 @@ public class TermsAndConditionsActivity extends PXActivity {
                 mMPTermsAndConditionsView.setVisibility(View.VISIBLE);
             }
         });
+        String version;
+        try {
+            final PackageInfo packageInfo = getPackageManager().getPackageInfo(getPackageName(), 0);
+            version = packageInfo.versionName;
+        } catch (final PackageManager.NameNotFoundException e) {
+            version = "1.0.0";
+        }
+        mTermsAndConditionsWebView.getSettings().setUserAgentString("MercadoLibre-Android/" + version);
 
         if (URLUtil.isValidUrl(data)) {
-            String version;
-            try {
-                final PackageInfo packageInfo = getPackageManager().getPackageInfo(getPackageName(), 0);
-                version = packageInfo.versionName;
-            } catch (final PackageManager.NameNotFoundException e) {
-                version = "1.0.0";
-            }
-            mTermsAndConditionsWebView.getSettings().setUserAgentString("MercadoLibre-Android/" + version);
             mTermsAndConditionsWebView.loadUrl(data);
         } else {
-            mTermsAndConditionsWebView.loadData(data, "text/html", "UTF-8");
+            String base64 = Base64.encodeToString(data.getBytes(StandardCharsets.UTF_8),
+                Base64.DEFAULT);
+            mTermsAndConditionsWebView.loadData(base64, "text/html; charset=utf-8", "base64");
         }
     }
 }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/TermsAndConditionsActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/TermsAndConditionsActivity.java
@@ -84,9 +84,9 @@ public class TermsAndConditionsActivity extends PXActivity {
         if (URLUtil.isValidUrl(data)) {
             mTermsAndConditionsWebView.loadUrl(data);
         } else {
-            String base64 = Base64.encodeToString(data.getBytes(StandardCharsets.UTF_8),
+            final String encodedUrl = Base64.encodeToString(data.getBytes(StandardCharsets.UTF_8),
                 Base64.DEFAULT);
-            mTermsAndConditionsWebView.loadData(base64, "text/html; charset=utf-8", "base64");
+            mTermsAndConditionsWebView.loadData(encodedUrl, "text/html; charset=utf-8", "base64");
         }
     }
 }


### PR DESCRIPTION
Changes were made to the TermsAndConditionsActivity class to display the MLM TyCs without redirecting the Mercado Livre login page. These changes also work for the MLB TyC page, which also had issues displaying terms as well.

## Motivación y Contexto
Show terms and conditions of use of the mercado crédito when selected on one tap. 

## Cómo probarlo
- In onetap, select "mercado crédito" option. 
- click in "términos y condiciones" option to show webview page. 
- select "carátula y domiciliación" or "terminos y condiciones"

## Screenshots
**MLM - ERROR:**
https://ibb.co/4ZnG102
**MLM - FIX**
 https://ibb.co/YbDTkZ6

## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
