### PR TITLE
[Release] 4.96.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## VERSION 4.96.2
+_25_11_2021_
+* FIX - NullPointerException is fixed when the checkout is started by onNewIntent.
+
 ## VERSION 4.96.1
 _18_11_2021_
 * FIX - Payment result screen fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # Current lib version
-libraryVersion=4.96.1
+libraryVersion=4.96.2
 # Compile versions
 buildTools=30.0.2
 minApiLevel=21

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutActivity.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/checkout/CheckoutActivity.java
@@ -75,6 +75,7 @@ public class CheckoutActivity extends PXActivity<CheckoutPresenter>
     @Override
     protected void onNewIntent(final Intent intent) {
         super.onNewIntent(intent);
+        setIntent(intent);
         if (intent.getData() != null) {
             final ExpressPayment.View fragment =
                 (ExpressPayment.View) getSupportFragmentManager().findFragmentByTag(TAG_ONETAP_FRAGMENT);


### PR DESCRIPTION
* FIX - NullPointerException is fixed when the checkout is started by onNewIntent.
