### PR TITLE
[Fix]: PXN-3379  New method is added to keep session.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+_XX_03_2022_
+* FIX - Parameter specified as non-null is null - solution: avoid to clear session with a new method
+
 ## VERSION 4.107.0
 _17_03_2022_
 * FIX - Congrats empty texts when paying with account money

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_congrats/CongratsDeepLinkActivity.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_congrats/CongratsDeepLinkActivity.kt
@@ -71,7 +71,7 @@ internal class CongratsDeepLinkActivity : AppCompatActivity() {
                 PaymentResultActivity.start(this, REQ_CODE_CONGRATS, congratsResult.paymentModel)
             }
             is CongratsResult.BusinessPaymentResult -> {
-                PaymentCongrats.show(congratsResult.paymentCongratsModel, this, REQ_CODE_CONGRATS)
+                PaymentCongrats.showWithSession(congratsResult.paymentCongratsModel, this, REQ_CODE_CONGRATS)
             }
             is CongratsPaymentResult.SkipCongratsResult -> {
                 DummyResultActivity.start(

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_congrats/PaymentCongrats.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/payment_congrats/PaymentCongrats.kt
@@ -26,6 +26,13 @@ object PaymentCongrats {
         }
     }
 
+    internal fun showWithSession(paymentCongratsModel: PaymentCongratsModel, activity: Activity, requestCode: Int) {
+        Intent(activity, BusinessPaymentResultActivity::class.java).also {
+            it.putExtra(PAYMENT_CONGRATS, paymentCongratsModel)
+            activity.startActivityForResult(it, requestCode)
+        }
+    }
+
     internal fun show(paymentCongratsModel: PaymentCongratsModel, fragment: Fragment, requestCode: Int) {
         Intent(fragment.context, BusinessPaymentResultActivity::class.java).also {
             it.putExtra(PAYMENT_CONGRATS, paymentCongratsModel)


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
<!--- ¿Por qué este cambio es requerido? ¿Qué problema resuelve? -->

The method that opens our congrats was duplicated in order to remove the line that cleans the session in order to keep it available for followings calls.

## Descripción
<!--- Describir los cambios en detalle -->

For semovi flow the integrator was opening our congrats twice, what implies a crash because the session was cleaned with the first attempt.

## Cómo probarlo
<!--- Para bug fixes: Describir cómo reproducir el comportamiento que generaba el bug -->
<!--- Para nuevos features: Se debe agregar el caso de uso a la app de ejemplos, y aquí se debe describir qué función de la app de ejemplos probar -->

1- Remove the finish() invocation on PostpaymentSampleActivity::32
2- Launch a PostPaymentFlow already configured in the test app
3- Try to navigate til the congrats screen
4- Close and reopen the congrats 
The app shouldn't crash when we open the congrats more than one time

## Screenshots
<!--- Para bug fixes: Incluir screenshots o videos del antes y después -->
<!--- Para nuevos features: Incluir screenshots o videos de la nueva UI -->
Error | Solution
-----|-----
![Error_bugfix_3379](https://user-images.githubusercontent.com/90635466/159571850-ed49e02b-c749-48b6-8729-6748903772cc.gif) | ![Solucion_bugfix_3379](https://user-images.githubusercontent.com/90635466/159571891-78cadd80-630b-4dc9-b842-f11b359a3450.gif)


## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
