### PR TITLE
Fix/pxn 3384

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+_XX_03_2022_
+* FIX - Parameter specified as non-null is null - parameter state
+
 ## VERSION 4.107.0
 _17_03_2022_
 * FIX - Congrats empty texts when paying with account money

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/one_tap/OneTapFragment.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/one_tap/OneTapFragment.java
@@ -258,7 +258,9 @@ public class OneTapFragment extends BaseFragment implements OneTap.View, ViewPag
             renderMode = (RenderMode) savedInstanceState.getSerializable(EXTRA_RENDER_MODE);
             navigationState =
                 (OneTap.NavigationState) savedInstanceState.getSerializable(EXTRA_NAVIGATION_STATE);
-            presenter.restoreState(savedInstanceState.getParcelable(BUNDLE_STATE));
+            if (savedInstanceState.getParcelable(BUNDLE_STATE) != null) {
+                presenter.restoreState(savedInstanceState.getParcelable(BUNDLE_STATE));
+            }
         } else {
             presenter.onFreshStart();
         }

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/one_tap/OneTapFragment.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/one_tap/OneTapFragment.java
@@ -38,6 +38,9 @@ import com.mercadopago.android.px.internal.experiments.Variant;
 import com.mercadopago.android.px.internal.experiments.VariantHandler;
 import com.mercadopago.android.px.internal.features.TermsAndConditionsActivity;
 import com.mercadopago.android.px.internal.features.disable_payment_method.DisabledPaymentMethodDetailDialog;
+import com.mercadopago.android.px.internal.features.generic_modal.GenericDialog;
+import com.mercadopago.android.px.internal.features.generic_modal.GenericDialogAction;
+import com.mercadopago.android.px.internal.features.generic_modal.GenericDialogItem;
 import com.mercadopago.android.px.internal.features.one_tap.add_new_card.OtherPaymentMethodFragment;
 import com.mercadopago.android.px.internal.features.one_tap.add_new_card.sheet_options.CardFormBottomSheetFragment;
 import com.mercadopago.android.px.internal.features.one_tap.add_new_card.sheet_options.CardFormBottomSheetModel;
@@ -57,9 +60,6 @@ import com.mercadopago.android.px.internal.features.one_tap.slider.SplitPaymentH
 import com.mercadopago.android.px.internal.features.one_tap.slider.SummaryViewAdapter;
 import com.mercadopago.android.px.internal.features.one_tap.slider.TitlePagerAdapter;
 import com.mercadopago.android.px.internal.features.one_tap.slider.TitlePagerAdapterV2;
-import com.mercadopago.android.px.internal.features.generic_modal.GenericDialog;
-import com.mercadopago.android.px.internal.features.generic_modal.GenericDialogAction;
-import com.mercadopago.android.px.internal.features.generic_modal.GenericDialogItem;
 import com.mercadopago.android.px.internal.features.pay_button.PayButton;
 import com.mercadopago.android.px.internal.features.pay_button.PayButtonFragment;
 import com.mercadopago.android.px.internal.features.security_code.SecurityCodeFragment;
@@ -83,10 +83,10 @@ import com.mercadopago.android.px.internal.viewmodel.SplitSelectionState;
 import com.mercadopago.android.px.internal.viewmodel.drawables.DrawableFragmentItem;
 import com.mercadopago.android.px.model.Currency;
 import com.mercadopago.android.px.model.DiscountConfigurationModel;
-import com.mercadopago.android.px.model.TermsAndConditionsLinks;
 import com.mercadopago.android.px.model.PayerCost;
 import com.mercadopago.android.px.model.Site;
 import com.mercadopago.android.px.model.StatusMetadata;
+import com.mercadopago.android.px.model.TermsAndConditionsLinks;
 import com.mercadopago.android.px.model.exceptions.MercadoPagoError;
 import com.mercadopago.android.px.model.internal.Application;
 import com.mercadopago.android.px.model.internal.DisabledPaymentMethod;
@@ -260,9 +260,7 @@ public class OneTapFragment extends BaseFragment implements OneTap.View, ViewPag
             renderMode = (RenderMode) savedInstanceState.getSerializable(EXTRA_RENDER_MODE);
             navigationState =
                 (OneTap.NavigationState) savedInstanceState.getSerializable(EXTRA_NAVIGATION_STATE);
-            if (savedInstanceState.getParcelable(BUNDLE_STATE) != null) {
-                presenter.restoreState(savedInstanceState.getParcelable(BUNDLE_STATE));
-            }
+            presenter.restoreState(savedInstanceState.getParcelable(BUNDLE_STATE));
         } else {
             presenter.onFreshStart();
             if (getArguments() != null && getArguments().getBoolean(EXTRA_FROM_DEEPLINK)) {
@@ -434,9 +432,10 @@ public class OneTapFragment extends BaseFragment implements OneTap.View, ViewPag
     public void onSaveInstanceState(@NonNull final Bundle outState) {
         outState.putSerializable(EXTRA_RENDER_MODE, renderMode);
         outState.putSerializable(EXTRA_NAVIGATION_STATE, navigationState);
-        if (presenter != null) {
-            outState.putParcelable(BUNDLE_STATE, presenter.getState());
+        if (presenter == null) {
+            presenter = createPresenter();
         }
+        outState.putParcelable(BUNDLE_STATE, presenter.getState());
         super.onSaveInstanceState(outState);
     }
 

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/one_tap/offline_methods/OfflineMethodsFragment.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/one_tap/offline_methods/OfflineMethodsFragment.kt
@@ -86,7 +86,9 @@ internal class OfflineMethodsFragment : Fragment(), OfflineMethods.View, BackHan
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState.putInt(EXTRA_BOTTOM_SHEET_STATE, bottomSheetBehavior.state)
+        if (this::bottomSheetBehavior.isInitialized) {
+            outState.putInt(EXTRA_BOTTOM_SHEET_STATE, bottomSheetBehavior.state)
+        }
     }
 
     private fun draw(model: OfflineMethods.Model) {

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/pay_button/PayButtonFragment.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/pay_button/PayButtonFragment.kt
@@ -118,7 +118,9 @@ internal class PayButtonFragment : BaseFragment(), PayButton.View, SecurityValid
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putInt(EXTRA_STATE, buttonStatus)
-        outState.putInt(EXTRA_VISIBILITY, button.visibility)
+        if (this::button.isInitialized) {
+            outState.putInt(EXTRA_VISIBILITY, button.visibility)
+        }
         outState.putBoolean(EXTRA_OBSERVING, observingPostPaymentAction)
         outState.putParcelable(BUNDLE_STATE, viewModel.state)
     }


### PR DESCRIPTION
[PXN-3384](https://mercadolibre.atlassian.net/browse/PXN-3384)

## Motivación y Contexto
Currently the app crashes when minimized a few times and the session is interrupted. In this case, the presenter is not recreated and an error occurs when we try to retrieve getParcebable by looking for bundlestate

Obs: When I did more tests I found 2 additional uninitialized lateinit var crashes where I made 2 adjustments in PayButtonFragment and OfflineMethodsFragment.

## Descripción
In OneTapFragment onSaveInstanceState, now we check if presenter is null and if is true, we call createPresenter again before call putParcelable 

## Cómo probarlo
In OneTap, click in add new card.
minimize the app in background
return to the application
minimize the app in background again.
return to the application and click and back button in card form.

## Screenshots
Error: https://ibb.co/ZVQhLty
Solution: https://ibb.co/Lv46Nfn

## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
