### PR TITLE
[Fix] getInstallments()- NullPointerException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+_XX_04_2022_
+* FIX - Crash when installments of payerCosts for credit cards is null.
+
 ##  VERSION 4.109.0
 _31_03_2022_
 * FIX - Parameter specified as non-null is null - parameter state

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/one_tap/OneTapPresenter.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/one_tap/OneTapPresenter.kt
@@ -433,7 +433,7 @@ internal class OneTapPresenter(
                 configuration.payerCost,
                 configuration.splitPayment,
                 bankInfoHelper
-            ).map(getCurrentOneTapItem())
+            ).map(oneTapItemRepository[configuration.customOptionId])
         )
         val experiment = experimentsRepository.getExperiment(KnownExperiment.INSTALLMENTS_HIGHLIGHT)
         if (getCurrentPayerCosts().size > 1 && experiment != null) {


### PR DESCRIPTION
The exception was thrown because a swipe was performed in between the biometric validation.

## Motivación y Contexto
To be able to make a payment with the payment method chosen at the time of pressing the 'PayButton' instead of the one that is selected after doing swipe.

## Descripción
https://app.bugsnag.com/mercadolibre/mercado-pago-android/errors/620abf99279f330007614d87
Instead of using the index of the current element we use the ID of the 'PaymentConfiguration'.
The 'payerCost' of AM is null, and for credit cards can't be.
When using 'getCurrentOneTapItem()' the ID was a credit card one, so the exception happened because PaymentTypes expected a credit card with installments and found a null.

## Cómo probarlo
To reproduce the behavior, you must display the AM payment method, press the pay button and do a quick swipe before the biometric validation activity is seen.

## Screenshots
https://ibb.co/7vpyfgw
https://ibb.co/LrgzKVP