### PR TITLE
[PXN-3673] added default message to avoid crash in dialog message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ _XX_04_2022
 * FEATURE - New layout consumer credits and new tag.
 * FEATURE - Adjust tag card consumer credits with size medium.
 * FEATURE - New background consumer credits.
+* FIX - added default message to avoid crash in dialog message
 
 ## VERSION 4.110.0
 _07_04_2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ _XX_04_2022
 * FEATURE - New layout consumer credits and new tag.
 * FEATURE - Adjust tag card consumer credits with size medium.
 * FEATURE - New background consumer credits.
-* FIX - added default message to avoid crash in dialog message
+* FIX - Added default message to avoid crash in dialog message
 
 ## VERSION 4.110.0
 _07_04_2022_

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/disable_payment_method/DisabledPaymentMethodDetailDialog.java
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/features/disable_payment_method/DisabledPaymentMethodDetailDialog.java
@@ -64,7 +64,7 @@ public class DisabledPaymentMethodDetailDialog extends MeliDialog {
 
         Session.getInstance().getTracker().track(new DisabledPaymentMethodDetailViewTracker());
 
-        content.setText(status != null && !status.isEnabled() ?
+        content.setText(status != null && !status.isEnabled() && status.getSecondaryMessage() != null ?
             status.getSecondaryMessage().getMessage() : getContent(statusDetail));
 
         final View linkText = view.findViewById(R.id.px_dialog_detail_payment_method_disable_link);
@@ -101,7 +101,7 @@ public class DisabledPaymentMethodDetailDialog extends MeliDialog {
             resId = R.string.px_dialog_detail_payment_method_disable_insufficient_amount;
             break;
         default:
-            resId = 0;
+            resId = R.string.px_payment_method_disable_title;
         }
 
         //noinspection ConstantConditions


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios en el Título de arriba -->

## Motivación y Contexto
Bugsnag: https://app.bugsnag.com/mercadolibre/mercado-pago-android/errors/625091669179eb00096947d2?event_id=6257f3cf009358a2e2920000&i=jr&m=li

These changes are to avoid a crash that occurs when the user clicks on a payment method that is not available and when the dialog is displayed, the message returns null.
_Maybe the backend response has been modified and the message fields are not returning what is causing the crash?_

Example mock up with the problem: https://run.mocky.io/v3/50064a16-9da5-40df-b58c-3745fc77e32f

## Descripción
I made 2 changes in the DisabledPaymentMethodDetailDialog class to avoid crash and display a default message in some cases. For example: You can not use this payment method.

## Cómo probarlo
You can try using this mock: https://run.mocky.io/v3/50064a16-9da5-40df-b58c-3745fc77e32f and select a disabled payment method and click it to show detail dialog. 

## Screenshots
<h3>Error:</h3>
<a href="https://ibb.co/nmBZFst"><img src="https://i.ibb.co/nmBZFst/pxn3673-crash.gif" alt="pxn3673-crash" border="0"></a>

<h3>Fix:</h3>
<a href="https://ibb.co/dMC9qJX"><img src="https://i.ibb.co/dMC9qJX/pxn3673-fix.gif" alt="pxn3673-fix" border="0"></a>


## Tipo de cambio (para el release manager)
- [ ] Breaking change (Fix o feature que cambia una funcionalidad existente o rompe firmas)
<!-- Describir qué cambia y como se hace la migración -->
- [ ] Mi cambio afecta a los integradores internos
<!-- Describir a qué equipos afecta para poder comunicarlo -->

## Compartir conocimiento
<!--- Compartir links a blog posts, patrones o librerías que se usaron para resolver este problema -->
