### PR TITLE
[PXN-3838] - Adjust update total value when use split and first installment CC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+_##_05_2022
+* FIX - Adjust update total value when use split and first installment consumer credits
+
 ## VERSION 4.114.1
 _05_05_2022
 * FEATURE - Bank account registration.

--- a/px-checkout/src/main/java/com/mercadopago/android/px/internal/mappers/SummaryViewModelMapper.kt
+++ b/px-checkout/src/main/java/com/mercadopago/android/px/internal/mappers/SummaryViewModelMapper.kt
@@ -15,7 +15,6 @@ import com.mercadopago.android.px.internal.view.SummaryDetailDescriptorMapper
 import com.mercadopago.android.px.internal.view.SummaryView
 import com.mercadopago.android.px.model.AmountConfiguration
 import com.mercadopago.android.px.model.DiscountConfigurationModel
-import com.mercadopago.android.px.model.PaymentTypes
 import com.mercadopago.android.px.model.commission.PaymentTypeChargeRule
 import java.math.BigDecimal
 
@@ -66,12 +65,13 @@ internal class SummaryViewModelMapper(
     }
 
     private fun getTotalAmountToPay(value: CustomTotal, discountModel: DiscountConfigurationModel): BigDecimal {
-        val hasInstallmentOrSplit = if (PaymentTypes.isAccountMoney(value.customOptionId) || value.selectedPayerCostIndex == null)
-            false
+        val hasInstallmentOrSplit = if (value.amountConfiguration.isNotNull())
+            (value.isSplitChecked) || value.amountConfiguration.payerCosts.size > 0
         else
-            value.selectedPayerCostIndex >= 0
-        return if (hasInstallmentOrSplit && value.selectedPayerCostIndex.isNotNull() && value.amountConfiguration.isNotNull() && value.selectedPayerCostIndex > 0
-            && !PaymentTypes.isAccountMoney(value.customOptionId)) {
+            false
+        return if (hasInstallmentOrSplit
+            && value.selectedPayerCostIndex.isNotNull()
+            && value.amountConfiguration.isNotNull()) {
             value.amountConfiguration.getCurrentPayerCost(value.isSplitChecked, value.selectedPayerCostIndex).totalAmount
         } else {
             amountRepository.getAmountToPay(value.paymentTypeId, discountModel)


### PR DESCRIPTION
## Motivación y Contexto
Correction in updating the value when using the split and also in the first installment of consumer credits.

## Descripción
<!--- Describir los cambios en detalle -->
After the last release, there were two problems in updating the total amount.
1. Updating when performing split is no longer updating the value.
2. Updating the first installment in the consumer is no longer updating the value.

## Cómo probarlo
User with consumer credits and split payment

## Screenshots
| Before | After |
|-------|---------|
<img width="405" alt="split-problema" src="https://user-images.githubusercontent.com/94557935/167155660-345e0987-3962-4664-8953-ee7ce7954256.png">|<img width="388" alt="split-corrigido" src="https://user-images.githubusercontent.com/94557935/167155684-07bdf21e-bd9b-4c1e-b142-50f0eb1edc3e.png">
<img width="398" alt="cc-com-problema" src="https://user-images.githubusercontent.com/94557935/167156345-8b128cd6-891c-4199-8c58-0818b072cc31.png">|<img width="391" alt="cc-corrigido" src="https://user-images.githubusercontent.com/94557935/167156383-54e70407-afc1-44b8-9312-54b810cc6b31.png">
<img width="401" alt="Captura de Tela 2022-05-06 às 11 40 05" src="https://user-images.githubusercontent.com/94557935/167156485-25d4c23e-1db6-4a03-aaec-7a390d2f8acb.png">|<img width="395" alt="debin" src="https://user-images.githubusercontent.com/94557935/167156520-5706d9f8-1897-49a8-9950-b454adacad34.png">
